### PR TITLE
Improves support for `struct`s in `proto`s

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Flexi Config Reader is a configuration language that employs a template-reference syntax
 in order to express repetitive & structured configuration parameters in a more concise
-manner. Usage of these constructs is optional. At it's core, the syntax uses concepts
+manner. Usage of these constructs is optional. At its core, the syntax uses concepts
 similar to those found in json & toml: nested structures of key/value pairs. One can draw
 parallels between some of the features found in this syntax and those made available by
 the jinja templating python library.
@@ -14,8 +14,8 @@ The syntax has three core concepts:
 1. `struct` - This is a concrete entry of data. A `struct` may contain other `struct`s as
    well as key/value pairs.
 2. `proto` - The `proto` keyword is used to define a template, which can be used to create
-   a `struct`. A `proto` may contain other `struct`s, as well as keys who's values are
-   represented by a variable
+   a `struct`. A `proto` may contain other `struct`s, `reference`s (see below), as well as
+   key/value pairs. The values in a proto (and all sub-objects) may be represented by a variable.
 3. `reference` - The `reference` keyword is used to turn a `proto` into a concrete `struct`.
    The `proto` is `reference`d, given a name, and all contained variables are given a value.
 
@@ -26,12 +26,12 @@ In summary, a `proto` that is `reference`d, effectively becomes a `struct`.
 1. `include` syntax - existing configuration files may be included by other files. There
    are no restrictions around a `proto` being defined in one file, then `reference`d in
    another file. This highlights one of the advantages of this syntax: the ability to
-   define a generic set of templates in one file, which will be use to multiple, repeated
-   concrete structs with different names and parameters in a different file.
+   define a generic set of templates in one file, which will be used to produce multiple,
+   repeated concrete structs with different names and parameters in a different file.
 2. key-value reference - Much like bash, the syntax provides the ability to reference a
    previously defined value by its key, and assign it to another key.
 3. Appended keys - While a `proto` defines a templated `struct`, one can add additional keys
-   to the `proto` when it is referenced.
+   to the resulting `struct` when the `proto` is referenced.
 4. Fully qualified keys - One may define the configuration parameters using a combination
    of the tree-like structure found in json along with fully qualified key value pairs.
    These can not be mixed within the same file however.
@@ -44,7 +44,6 @@ is not significant it is convenient in order to better view the structure of the
 ### `struct` keyword
 
 The `struct` keyword is used to define a structure of data, e.g.
-
 
 ```
 struct foo
@@ -81,26 +80,24 @@ The `proto` keyword is used to define a templated definition of a `struct`, e.g.
 struct protos
 
   proto foo
-
     key1 = 0
     key2 = 1.4
     key3 = $KEY3
 
     struct bar
-      ...
+      key_a = 0x1A2B
+      key_b = $KEY_B
     end bar
-
   end foo
 
 end protos
 ```
 
 The above example defines a `proto` called "foo" with two concrete keys and a variable key `key3`. There is
-also a nested struct (which may contain variable keys as well).
+also a nested struct (which also contains a contrete key and a variable key `key_b`).
 
 This `proto` does not add anything to the configuration parameters as is. It must be `reference`d in order to
 turn it into a concrete `struct` of data.
-
 
 ### `reference` keyword
 
@@ -109,14 +106,15 @@ The `reference` keyword is used to turn a `proto` into a `struct`. Following on 
 ```
 reference protos.foo as fuzz
   $KEY3 = "apple"
+  $KEY_B = 3.14159
   +extra_key = 0x7FF
 end fuzz
 ```
 
 The above example introduces the following concepts:
 
-1. When referencing a `proto`, the fully qualified name must be used (i.e. `protos.foo` instead of `foo`).
-2. The variable `$KEY3` that was introduced in `protos.foo` is given a value when the `proto` is `reference`d.
+1. When referencing a `proto`, the fully qualified name of the proto must be used (i.e. `protos.foo` instead of `foo`).
+2. The variables `$KEY3` and `$KEY_B` that were introduced in `protos.foo` and `protos.foo.bar` respectively are given values when the `proto` is `reference`d.
 3. `+extra_key` is an appended key. The `proto` "protos.foo" does not contain this key, but the resulting `struct fuzz`
    will contain this additional key.
 
@@ -130,7 +128,8 @@ struct fuzz
   extra_key = 0x7FF
 
   struct bar
-    ...
+    key_a = 0x1A2B
+    key_b = 3.14159
   end bar
 end fuzz
 ```
@@ -151,9 +150,8 @@ struct bar
 end bar
 ```
 
-In this case, the key `bar.key2` would have the value of `foo.key2`, or in this case `1.4`. This construct can be
-used within the `struct`, `proto` or `reference` constructs.
-
+In this case, the key `bar.key2` is given the value of `foo.key2`, or in this case `1.4`. This construct can be
+used within the `struct`, `proto` or `reference` constructs. The syntax is `$(<flat_key>)`.
 
 ### Value types
 
@@ -163,8 +161,7 @@ The following value types are supported:
 2. Floating-point numbers (standard or scientific notation)
 3. Hexadecimal numbers (which resolve to a decimal number)
 4. double-quoted string
-5. List - a bracket-enclosed list of same-typed values from the types listed above (i.e. one may define a list
-   of strings or floating-point numbers, but not a mixed combination of the two).
+5. List - a bracket-enclosed, comma-separated list of same-typed values from the types listed above (i.e. one may define a list of strings or floating-point numbers, but not a mixed combination of the two).
 
 # Parsers
 
@@ -178,11 +175,14 @@ examples which demonstrate more of the capabilities of the language.
 The C++ implementation uses the [`taocpp::pegtl`](https://github.com/taocpp/PEGTL) library to define the grammar.
 `PEGTL` uses a templatized syntax to define the grammar (which can be found [here](cpp/config_grammar.h)).  This is used
 for parsing the raw config file, along with a set of [actions](cpp/config_actions.h) which define how to act on the parse
-output.  Once the raw config files are parsed, there is a second pass that occurs in order to convert any `reference`s to
-`proto`s into `struct`s as mentioned above.
+output.  Once the raw config files are parsed, there is a second pass that does the following:
+1. Finds all protos defined in the parsed output
+2. Merges all nested structs into a single struct
+3. Resolves all references (and their associated variables), turning references to `proto`s into `struct`s.
+4. Unflattens any flat key/value pairs
+5. Resolves key-value references
 
-`PEGTL` also provides some additional functionality to analyze the defined grammar and to generate a parse-tree from a
-supplied configuration file.
+`PEGTL` also provides some additional functionality to analyze the defined grammar and to generate a parse-tree from a supplied configuration file.
 
 ### Dependencies
 
@@ -231,5 +231,5 @@ directory. See the googletest documentation for options.
 In addition to the tests, there are a number of simple applications that provide example code for the library usage.
 
  *  [`config_test`](cpp/config_test.cpp) - In the process of being converted to an actual unittest, this application executes a parsing run on a variety of [example config files](examples).
- *  [`config_build`](cpp/config_build.cpp) - This application can be used to parse a config file. Usage: `./cpp/config_reader ../example/config_example5.cfg`.
+ *  [`config_build`](cpp/config_build.cpp) - This application can be used to parse a config file and build the resulting config tree. Usage: `./cpp/config_reader ../example/config_example5.cfg`.
  *  [`config_reader_example`](cpp/config_reader_example.cpp) - This reads the [`config_example5.cfg`](examples/config_example5.cfg) configuration file and attempts to read a variety of variables from it. This uses a verbose mode, which generates a lot of debug printouts, tracing the parsing and construction of the config data.

--- a/cpp/config_actions.h
+++ b/cpp/config_actions.h
@@ -118,7 +118,7 @@ template <>
 struct action<HEX> {
   template <typename ActionInput>
   static void apply(const ActionInput& in, ActionData& out) {
-    const auto hex = std::stoi(in.string(), nullptr, 16);
+    const auto hex = std::stoull(in.string(), nullptr, 16);
 #if VERBOSE_DEBUG
     CONFIG_ACTION_TRACE("In HEX action: {}|{}|0x{:X}", in.string(), hex, hex);
 #endif

--- a/cpp/config_classes.h
+++ b/cpp/config_classes.h
@@ -43,6 +43,7 @@ enum class Type {
   kValueLookup,
   kVar,
   kStruct,
+  kStructInProto,
   kProto,
   kReference,
   kUnknown
@@ -231,8 +232,8 @@ class ConfigStructLike : public ConfigBaseClonable<ConfigBase, ConfigStructLike>
 
 class ConfigStruct : public ConfigBaseClonable<ConfigStructLike, ConfigStruct> {
  public:
-  ConfigStruct(std::string name, std::size_t depth)
-      : ConfigBaseClonable(Type::kStruct, name, depth){};
+  ConfigStruct(std::string name, std::size_t depth, Type type = Type::kStruct)
+      : ConfigBaseClonable(type, name, depth){};
 
   void stream(std::ostream& os) const override {
     const auto ws = std::string(depth * tw, ' ');

--- a/cpp/config_exceptions.h
+++ b/cpp/config_exceptions.h
@@ -1,6 +1,11 @@
 #pragma once
 
+#include <fmt/format.h>
+
 #include <exception>
+
+#define THROW_EXCEPTION(E_TYPE, MSG_F, ...) \
+  throw E_TYPE(fmt::format(MSG_F " - {}:{}", ##__VA_ARGS__, __FILE__, __LINE__));
 
 namespace config {
 

--- a/cpp/config_grammar.h
+++ b/cpp/config_grammar.h
@@ -123,14 +123,14 @@ struct VALUE : peg::sor<VAL_, LIST> {};
 // Account for all reserved keywords when looking for keys
 struct KEY : peg::seq<peg::not_at<RESERVED>, peg::lower, peg::star<peg::identifier_other>> {};
 struct FLAT_KEY : peg::list<KEY, peg::one<'.'>> {};
-struct REF_VARADD : peg::seq<peg::one<'+'>, KEY, KVs, VALUE, TAIL> {};
-struct REF_VARSUB : peg::seq<VAR, KVs, VALUE, TAIL> {};
-
 struct VAR_REF : peg::seq<TAO_PEGTL_STRING("$("), FLAT_KEY, peg::one<')'>> {};
+
+struct REF_VARADD : peg::seq<peg::one<'+'>, KEY, KVs, VALUE, TAIL> {};
+struct REF_VARSUB : peg::seq<VAR, KVs, peg::sor<VALUE, VAR_REF>, TAIL> {};
 
 struct FULLPAIR : peg::seq<FLAT_KEY, KVs, peg::sor<VALUE, VAR_REF>, TAIL> {};
 struct PAIR : peg::seq<KEY, KVs, peg::sor<VALUE, VAR_REF>, TAIL> {};
-struct PROTO_PAIR : peg::seq<KEY, KVs, peg::sor<VAR, VAR_REF, VALUE>, TAIL> {};
+struct PROTO_PAIR : peg::seq<KEY, KVs, peg::sor<VALUE, VAR_REF, VAR>, TAIL> {};
 
 struct END : peg::seq<ENDk, SP, KEY> {};
 
@@ -146,8 +146,12 @@ struct STRUCTc;
 struct STRUCTs : peg::seq<STRUCTk, SP, KEY, TAIL> {};
 struct STRUCT : peg::seq<STRUCTs, STRUCTc, END, WS_> {};
 
-struct PROTOc : peg::plus<peg::sor<PROTO_PAIR, STRUCT, REFERENCE>> {};
-struct STRUCTc : peg::plus<peg::sor<STRUCT, PAIR, REFERENCE, PROTO>> {};
+// Special definition of a struct contained in a proto
+struct STRUCT_IN_PROTOc;
+struct STRUCT_IN_PROTO : peg::seq<STRUCTs, PROTOc, END, WS_> {};
+
+struct PROTOc : peg::plus<peg::sor<PROTO_PAIR, STRUCT_IN_PROTO, REFERENCE>> {};
+struct STRUCTc : peg::plus<peg::sor<PAIR, STRUCT, REFERENCE, PROTO>> {};
 
 // Include syntax
 struct INCLUDE : peg::seq<TAO_PEGTL_KEYWORD("include"), SP, filename::grammar, TAIL> {};

--- a/cpp/config_helpers.h
+++ b/cpp/config_helpers.h
@@ -58,19 +58,19 @@ inline auto checkForErrors(const config::types::CfgMap& cfg1, const config::type
                            const std::string& key) -> bool {
   const auto dict_count = isStructLike(cfg1.at(key)) + isStructLike(cfg2.at(key));
   if (dict_count == 0) {  // Neither is a dictionary. We don't support duplicate keys
-    throw config::DuplicateKeyException(fmt::format("Duplicate key '{}' found at {} and {}!", key,
-                                                    cfg1.at(key)->loc(), cfg2.at(key)->loc()));
+    THROW_EXCEPTION(config::DuplicateKeyException, "Duplicate key '{}' found at {} and {}!", key,
+                    cfg1.at(key)->loc(), cfg2.at(key)->loc());
     // print(f"Found duplicate key: '{key}' with values '{dict1[key]}' and '{dict2[key]}'!!!")
   } else if (dict_count == 1) {  // One dictionary, but not the other, can't merge these
-    throw config::MismatchKeyException(
-        fmt::format("Mismatch types for key '{}' found at {} and {}! Both keys must point to "
+    THROW_EXCEPTION(config::MismatchKeyException,
+                    "Mismatch types for key '{}' found at {} and {}! Both keys must point to "
                     "structs, can't merge these.",
-                    key, cfg1.at(key)->loc(), cfg2.at(key)->loc()));
+                    key, cfg1.at(key)->loc(), cfg2.at(key)->loc());
   }
   if (cfg1.at(key)->type != cfg2.at(key)->type) {
-    throw config::MismatchTypeException(
-        fmt::format("Types at key '{}' must match. cfg1 is '{}', cfg2 is '{}'.", key,
-                    cfg1.at(key)->type, cfg2.at(key)->type));
+    THROW_EXCEPTION(config::MismatchTypeException,
+                    "Types at key '{}' must match. cfg1 is '{}', cfg2 is '{}'.", key,
+                    cfg1.at(key)->type, cfg2.at(key)->type);
   }
   return dict_count == 2;  // All good if both are dictionaries (for now);
 }
@@ -160,8 +160,8 @@ inline void replaceProtoVar(config::types::CfgMap& cfg_map, const config::types:
       auto v_var = dynamic_pointer_cast<config::types::ConfigVar>(v);
       // Pull the value from the reference vars and add it to the structure.
       if (!ref_vars.contains(v_var->name)) {
-        throw config::UndefinedReferenceVarException(
-            fmt::format("Attempting to replace '{}' with undefined var: '{}'.", k, v_var->name));
+        THROW_EXCEPTION(config::UndefinedReferenceVarException,
+                        "Attempting to replace '{}' with undefined var: '{}'.", k, v_var->name);
       }
       cfg_map[k] = ref_vars.at(v_var->name);
     } else if (v->type == config::types::Type::kString) {
@@ -230,9 +230,9 @@ inline auto getNestedConfig(const config::types::CfgMap& cfg, const std::vector<
     // otherwise we can't access the `data` member.
     struct_like = dynamic_pointer_cast<config::types::ConfigStructLike>(content->at(key));
     if (struct_like == nullptr) {
-      throw config::InvalidTypeException(
-          fmt::format("Expected value at '{}' to be a struct-like object, but got {} type instead.",
-                      rejoined, content->at(key)->type));
+      THROW_EXCEPTION(config::InvalidTypeException,
+                      "Expected value at '{}' to be a struct-like object, but got {} type instead.",
+                      rejoined, content->at(key)->type);
     }
     // Pull out the contents of the struct-like and move on to the next iteration.
     content = &(struct_like->data);
@@ -295,8 +295,9 @@ inline void unflatten(const std::string& flat_key, config::types::CfgMap& cfg,
     // Get this element, and find the internal data and assign it to our pointer.
     auto v = cfg[head];
     if (!config::helpers::isStructLike(v)) {
-      throw std::runtime_error(fmt::format(
-          "In unflatten2, expected {} to be struct-like, but found {} instead.", head, v->type));
+      THROW_EXCEPTION(std::runtime_error,
+                      "In unflatten, expected {} to be struct-like, but found {} instead.", head,
+                      v->type);
     }
     next_cfg = &(dynamic_pointer_cast<config::types::ConfigStructLike>(v)->data);
   } else {

--- a/cpp/config_helpers.h
+++ b/cpp/config_helpers.h
@@ -46,8 +46,10 @@ inline constexpr bool accepts_list_v = accepts_list<T>::value;
 namespace config::helpers {
 
 inline auto isStructLike(const std::shared_ptr<config::types::ConfigBase>& el) -> bool {
-  return el->type == config::types::Type::kStruct || el->type == config::types::Type::kProto ||
-         el->type == config::types::Type::kReference;
+  // TODO: Change this to be a `dynamic_pointer_cast`. As is, it's a bit of a maintenance burden.
+  return el->type == config::types::Type::kStruct ||
+         el->type == config::types::Type::kStructInProto ||
+         el->type == config::types::Type::kProto || el->type == config::types::Type::kReference;
 }
 
 // Three cases to check for:
@@ -322,7 +324,8 @@ inline void unflatten(const std::string& flat_key, config::types::CfgMap& cfg,
 inline void removeEmpty(config::types::CfgMap& cfg) {
   std::vector<std::remove_reference_t<decltype(cfg)>::key_type> to_erase{};
   for (auto& kv : cfg) {
-    if (kv.second->type == config::types::Type::kStruct) {
+    if (kv.second->type == config::types::Type::kStruct ||
+        kv.second->type == config::types::Type::kStructInProto) {
       auto s = dynamic_pointer_cast<config::types::ConfigStruct>(kv.second);
       removeEmpty(s->data);
       if (s->data.empty()) {

--- a/cpp/config_reader.cpp
+++ b/cpp/config_reader.cpp
@@ -279,6 +279,12 @@ void ConfigReader::resolveReferences(config::types::CfgMap& cfg_map, const std::
       // Call recursively in case the current reference has another reference
       resolveReferences(new_struct->data, utils::makeName(new_name, k), ref_vars);
 
+    } else if (v->type == config::types::Type::kStructInProto) {
+      // Resolve all proto/reference variables based on the values provided.
+      auto struct_like = dynamic_pointer_cast<config::types::ConfigStructLike>(v);
+      config::helpers::replaceProtoVar(struct_like->data, ref_vars);
+
+      resolveReferences(struct_like->data, new_name, ref_vars);
     } else if (v->type == config::types::Type::kStruct) {
       resolveReferences(dynamic_pointer_cast<config::types::ConfigStructLike>(v)->data, new_name,
                         ref_vars);

--- a/cpp/config_reader.cpp
+++ b/cpp/config_reader.cpp
@@ -112,9 +112,9 @@ void ConfigReader::convert(const std::string& value_str, float& value) const {
   std::size_t len{0};
   value = std::stof(value_str, &len);
   if (len != value_str.size()) {
-    throw config::MismatchTypeException(
-        fmt::format("Error while converting '{}' to type float. Processed {} of {} characters",
-                    value_str, len, value_str.size()));
+    THROW_EXCEPTION(config::MismatchTypeException,
+                    "Error while converting '{}' to type float. Processed {} of {} characters",
+                    value_str, len, value_str.size());
   }
 }
 
@@ -122,9 +122,9 @@ void ConfigReader::convert(const std::string& value_str, double& value) const {
   std::size_t len{0};
   value = std::stod(value_str, &len);
   if (len != value_str.size()) {
-    throw config::MismatchTypeException(
-        fmt::format("Error while converting '{}' to type double. Processed {} of {} characters",
-                    value_str, len, value_str.size()));
+    THROW_EXCEPTION(config::MismatchTypeException,
+                    "Error while converting '{}' to type double. Processed {} of {} characters",
+                    value_str, len, value_str.size());
   }
 }
 
@@ -132,9 +132,9 @@ void ConfigReader::convert(const std::string& value_str, int& value) const {
   std::size_t len{0};
   value = std::stoi(value_str, &len);
   if (len != value_str.size()) {
-    throw config::MismatchTypeException(
-        fmt::format("Error while converting '{}' to type int. Processed {} of {} characters",
-                    value_str, len, value_str.size()));
+    THROW_EXCEPTION(config::MismatchTypeException,
+                    "Error while converting '{}' to type int. Processed {} of {} characters",
+                    value_str, len, value_str.size());
   }
 }
 
@@ -142,9 +142,9 @@ void ConfigReader::convert(const std::string& value_str, int64_t& value) const {
   std::size_t len{0};
   value = std::stoll(value_str, &len);
   if (len != value_str.size()) {
-    throw config::MismatchTypeException(
-        fmt::format("Error while converting '{}' to type int64_t. Processed {} of {} characters",
-                    value_str, len, value_str.size()));
+    THROW_EXCEPTION(config::MismatchTypeException,
+                    "Error while converting '{}' to type int64_t. Processed {} of {} characters",
+                    value_str, len, value_str.size());
   }
 }
 
@@ -152,9 +152,9 @@ void ConfigReader::convert(const std::string& value_str, bool& value) const {
   std::size_t len{0};
   value = static_cast<bool>(std::stoi(value_str, &len));
   if (len != value_str.size()) {
-    throw config::MismatchTypeException(
-        fmt::format("Error while converting '{}' to type bool. Processed {} of {} characters",
-                    value_str, len, value_str.size()));
+    THROW_EXCEPTION(config::MismatchTypeException,
+                    "Error while converting '{}' to type bool. Processed {} of {} characters",
+                    value_str, len, value_str.size());
   }
 }
 

--- a/cpp/config_test.cpp
+++ b/cpp/config_test.cpp
@@ -91,9 +91,13 @@ end test2\n\
     ret &= runTest<config::grammar>(in, pdot);
   }
 
-  for (size_t i = 1; i <= 6; ++i) {
+  for (size_t i = 1;; ++i) {
     const auto cfg_file =
         std::filesystem::path(EXAMPLE_DIR) / ("config_example" + std::to_string(i) + ".cfg");
+    if (!std::filesystem::exists(cfg_file)) {
+      break;
+    }
+
     peg::file_input in(cfg_file);
     ret &= runTest<config::grammar>(in, pdot);
   }

--- a/examples/config_example7.cfg
+++ b/examples/config_example7.cfg
@@ -1,0 +1,54 @@
+
+
+include config_example6.cfg
+
+struct protos
+
+    proto joint_proto
+      leg = $LEG
+      dof = "${LEG}.$DOF"  # An example of using variables in a string
+
+      struct nested_w_var
+        my_value = $VALUE_IN_STRUCT
+      end nested_w_var
+    end joint_proto
+
+    proto leg_proto
+      key_1 = "foo"
+      key_2 = "bar"
+      key_3 = $LEG
+
+      reference protos.joint_proto as hx  # Can we make the 'hx' here be represented by $DOF?
+        +extra_key = 1.e-3
+      end hx
+    end leg_proto
+end protos
+
+struct outer
+    my_key = "foo"
+    n_key = 1
+    var_ref = $(outer.fl.key_3)
+
+    struct inner   # Another comment "here"
+      key = 1
+      #pair = "two"
+      val = 1.232e10
+
+      struct test1
+        key = [-0.123, 1.23e2, 0.123] # -5
+      end test1
+
+      key_after = 3
+    end inner
+
+    key_between = 4
+
+    reference protos.leg_proto as fl
+      $LEG = "fl"
+      $DOF = "hx"
+      $VALUE_IN_STRUCT = 3.14159
+    end fl
+end outer
+
+
+


### PR DESCRIPTION
- Adds support for defining `VAR` types within a `struct` that is a sub-object of a `proto`.
- During the `resolveReferences` and `replaceProtoVar` phase, any variables contained within a `struct` will also be resolved.
- Minor improvements to the grammer
- Adds helper macro for throwing exceptions.