### PR TITLE
Adds support for ref vars in value refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ the jinja templating python library.
 
 The syntax has three core concepts:
 
-1. `struct` - This is a concrete entry of data. A `struct` may contain other `struct`s as
+1. [`struct`](#struct-keyword) - This is a concrete entry of data. A `struct` may contain other `struct`s as
    well as key/value pairs.
-2. `proto` - The `proto` keyword is used to define a template, which can be used to create
+2. [`proto`](#proto-keyword) - The `proto` keyword is used to define a template, which can be used to create
    a `struct`. A `proto` may contain other `struct`s, `reference`s (see below), as well as
    key/value pairs. The values in a proto (and all sub-objects) may be represented by a variable.
-3. `reference` - The `reference` keyword is used to turn a `proto` into a concrete `struct`.
-   The `proto` is `reference`d, given a name, and all contained variables are given a value.
+3. [`reference`](#reference-keyword) - The `reference` keyword is used to turn a `proto` into a concrete
+   `struct`. The `proto` is `reference`d, given a name, and all contained variables are given a value.
 
 In summary, a `proto` that is `reference`d, effectively becomes a `struct`.
 
@@ -28,8 +28,8 @@ In summary, a `proto` that is `reference`d, effectively becomes a `struct`.
    another file. This highlights one of the advantages of this syntax: the ability to
    define a generic set of templates in one file, which will be used to produce multiple,
    repeated concrete structs with different names and parameters in a different file.
-2. key-value reference - Much like bash, the syntax provides the ability to reference a
-   previously defined value by its key, and assign it to another key.
+2. [key-value reference](#key-value-references) - Much like bash, the syntax provides the ability
+   to reference apreviously defined value by its key, and assign it to another key.
 3. Appended keys - While a `proto` defines a templated `struct`, one can add additional keys
    to the resulting `struct` when the `proto` is referenced.
 4. Fully qualified keys - One may define the configuration parameters using a combination
@@ -114,7 +114,10 @@ end fuzz
 The above example introduces the following concepts:
 
 1. When referencing a `proto`, the fully qualified name of the proto must be used (i.e. `protos.foo` instead of `foo`).
-2. The variables `$KEY3` and `$KEY_B` that were introduced in `protos.foo` and `protos.foo.bar` respectively are given values when the `proto` is `reference`d.
+2. The variables `$KEY3` and `$KEY_B` that were introduced in `protos.foo` and `protos.foo.bar` respectively are given values when the `proto` is `reference`d. These variables can be used in the following situations
+    - Alone, as the value in a key/value pair
+    - Within a string value (e.g. `key = "refer.to.$KEY3.thing"`)
+    - Within a [key-value reference](#key-value-references) (e.g. `key = $(reference.$THIS.var)`)
 3. `+extra_key` is an appended key. The `proto` "protos.foo" does not contain this key, but the resulting `struct fuzz`
    will contain this additional key.
 
@@ -151,7 +154,8 @@ end bar
 ```
 
 In this case, the key `bar.key2` is given the value of `foo.key2`, or in this case `1.4`. This construct can be
-used within the `struct`, `proto` or `reference` constructs. The syntax is `$(<flat_key>)`.
+used within the `struct`, `proto` or `reference` constructs. The syntax is `$(path.to.key)`. As mentioned in the
+[`reference` section](#reference-keyword), a key-value reference may include variables internally (e.g. `$(path.to.$KEY)`.
 
 ### Value types
 

--- a/cpp/config_grammar.h
+++ b/cpp/config_grammar.h
@@ -123,7 +123,9 @@ struct VALUE : peg::sor<VAL_, LIST> {};
 // Account for all reserved keywords when looking for keys
 struct KEY : peg::seq<peg::not_at<RESERVED>, peg::lower, peg::star<peg::identifier_other>> {};
 struct FLAT_KEY : peg::list<KEY, peg::one<'.'>> {};
-struct VAR_REF : peg::seq<TAO_PEGTL_STRING("$("), FLAT_KEY, peg::one<')'>> {};
+
+struct VAR_REF : peg::seq<TAO_PEGTL_STRING("$("), peg::list<peg::sor<KEY, VAR>, peg::one<'.'>>,
+                          peg::one<')'>> {};
 
 struct REF_VARADD : peg::seq<peg::one<'+'>, KEY, KVs, VALUE, TAIL> {};
 struct REF_VARSUB : peg::seq<VAR, KVs, peg::sor<VALUE, VAR_REF>, TAIL> {};

--- a/cpp/utils.h
+++ b/cpp/utils.h
@@ -9,10 +9,23 @@
 #include <vector>
 
 namespace utils {
-inline auto trim(std::string s, const std::string& sep = " \n\t\v\r\f") -> std::string {
+/// \brief Removes all instances of any char foundi in `sep` from the beginning and end of `s`
+/// \param[in] s - Input string
+/// \paarm[in] sep - A string containing all `char`s to trim
+/// \return The trimmed string
+inline auto trim(std::string s, const std::string& chars = " \n\t\v\r\f") -> std::string {
   std::string str(std::move(s));
-  str.erase(0, str.find_first_not_of(sep));
-  str.erase(str.find_last_not_of(sep) + 1U);
+  str.erase(0, str.find_first_not_of(chars));
+  str.erase(str.find_last_not_of(chars) + 1U);
+  return str;
+}
+
+inline auto removeSubStr(std::string s, const std::string& sub_str) -> std::string {
+  std::string str(std::move(s));
+  std::size_t pos = str.find(sub_str);
+  if (pos != std::string::npos) {
+    str.erase(pos, sub_str.size());
+  }
   return str;
 }
 

--- a/examples/config_example8.cfg
+++ b/examples/config_example8.cfg
@@ -8,7 +8,7 @@ struct protos
     key1 = $VAR1
     key2 = $VAR2
     not_a_var = 27
-    ref_var = $(concrete.leg1.joint2.key1)  # This one is tricky!
+    ref_var = $(concrete.leg1.$VAR1)  # This one is tricky!
   end joint_proto
 
   # Another comment here!
@@ -18,12 +18,12 @@ struct protos
 		key_b = $KEY_B
 
     reference protos.joint_proto as joint1
-      $VAR1 = "joint1.var1"
+      $VAR1 = "joint1.key1"
 			$VAR2 = "joint1.var2"
     end joint1
 
     reference protos.joint_proto as joint2
-      $VAR1 = "joint2.var1"
+      $VAR1 = "joint2.key1"
 			$VAR2 = "joint2.var2"
     end joint2
 	end leg_proto


### PR DESCRIPTION
- Supports using reference variables (e.g. `$VAR`) in value references (e.g. `$(value.ref)`).
- When resolving references, the reference variables will be replaced in the value reference in the same manner that they are replaced within strings containing value references.

- Adds additional tests for the `REF_VAR` grammar rule as well as modifies [`config_example8.cfg`](../blob/main/examples/config_example8.cfg) to make use of and test this new feature.