### PR TITLE
Replaces `end` keyword with curly braces

### DIFF
--- a/cpp/config_actions.h
+++ b/cpp/config_actions.h
@@ -593,21 +593,6 @@ struct action<REFERENCE> {
 template <>
 struct action<END> {
   static void apply0(ActionData& out) {
-    if (out.keys.size() < 2) {
-      out.print(std::cerr);
-      THROW_EXCEPTION(InvalidStateException, "[END] Expected 2 or more keys, found {}.",
-                      out.keys.size());
-    }
-    const auto end_key = out.keys.back();
-    out.keys.pop_back();
-    // If we've found an end tag, then the last two keys should match. If they don't, the config is
-    // malformed.
-    const auto is_match = end_key == out.keys.back();
-    if (!is_match) {
-      out.print(std::cerr);
-      THROW_EXCEPTION(InvalidConfigException, "End key mismatch: {} != {}.", end_key,
-                      out.keys.back());
-    }
     out.depth--;
     CONFIG_ACTION_DEBUG("Depth is now {}", out.depth);
   }

--- a/cpp/config_grammar.h
+++ b/cpp/config_grammar.h
@@ -98,9 +98,8 @@ struct STRUCTk : TAO_PEGTL_KEYWORD("struct") {};
 struct PROTOk : TAO_PEGTL_KEYWORD("proto") {};
 struct REFk : TAO_PEGTL_KEYWORD("reference") {};
 struct ASk : TAO_PEGTL_KEYWORD("as") {};
-struct ENDk : TAO_PEGTL_KEYWORD("end") {};
 
-struct RESERVED : peg::sor<STRUCTk, PROTOk, REFk, ASk, ENDk> {};
+struct RESERVED : peg::sor<STRUCTk, PROTOk, REFk, ASk> {};
 
 struct HEXTAG : peg::seq<peg::one<'0'>, peg::one<'x', 'X'>> {};
 struct HEX : peg::seq<HEXTAG, peg::plus<peg::xdigit>> {};
@@ -151,18 +150,18 @@ struct FULLPAIR : peg::seq<FLAT_KEY, KVs, peg::sor<VALUE, VAR_REF, EXPRESSION>, 
 struct PAIR : peg::seq<KEY, KVs, peg::sor<VALUE, VAR_REF, EXPRESSION>, TAIL> {};
 struct PROTO_PAIR : peg::seq<KEY, KVs, peg::sor<VALUE, VAR_REF, EXPRESSION, VAR>, TAIL> {};
 
-struct END : peg::seq<ENDk, SP, KEY> {};
+struct END : CBc {};
 
-struct REFs : peg::seq<REFk, SP, FLAT_KEY, SP, ASk, SP, KEY, TAIL> {};
+struct REFs : peg::seq<REFk, SP, FLAT_KEY, SP, ASk, SP, KEY, CBo, TAIL> {};
 struct REFc : peg::plus<peg::sor<REF_VARSUB, REF_VARADD>> {};
 struct REFERENCE : peg::seq<REFs, REFc, END, TAIL> {};
 
 struct PROTOc;
-struct PROTOs : peg::seq<PROTOk, SP, KEY, TAIL> {};
+struct PROTOs : peg::seq<PROTOk, SP, KEY, CBo, TAIL> {};
 struct PROTO : peg::seq<PROTOs, PROTOc, END, TAIL> {};
 
 struct STRUCTc;
-struct STRUCTs : peg::seq<STRUCTk, SP, KEY, TAIL> {};
+struct STRUCTs : peg::seq<STRUCTk, SP, KEY, CBo, TAIL> {};
 struct STRUCT : peg::seq<STRUCTs, STRUCTc, END, TAIL> {};
 
 // Special definition of a struct contained in a proto

--- a/cpp/config_reader.cpp
+++ b/cpp/config_reader.cpp
@@ -268,8 +268,11 @@ void ConfigReader::resolveReferences(config::types::CfgMap& cfg_map, const std::
       logger::error("Something seems off. Key '{}' is null.", k);
       logger::error("Contents of cfg_map: \n{}", cfg_map);
       THROW_EXCEPTION(config::InvalidConfigException,
-                      "\n\tbase_name: {}\n\tSomething is wrong. Key '{}' is NULL.\n\tContents of "
-                      "cfg_map: \n\t{}",
+                      "\n"
+                      "\tbase_name: {}\n"
+                      "\tSomething is wrong. Key '{}' is NULL.\n"
+                      "\tContents of cfg_map: \n"
+                      "\t{}",
                       base_name, k, cfg_map);
     }
     const auto new_name = utils::makeName(base_name, k);

--- a/examples/config_example1.cfg
+++ b/examples/config_example1.cfg
@@ -1,19 +1,18 @@
 another_key = "test"
 
-struct test1
+struct test1 {
     key1 = "value"
     key2 = 1.342    # test comment here
     key3 = {{ 0.5 * (-0.25 * pi) }}
     f = ["foo", "bar", "baz"]
-end test1
+}
 
-struct test2
+struct test2 {
     my_key = "foo"
     n_key = 0x1234
     var_ref = $(test1.key3)
 
-
     # End comment
-end test2
+}
 
 solo_key  =     10.1

--- a/examples/config_example2.cfg
+++ b/examples/config_example2.cfg
@@ -1,19 +1,19 @@
-struct test1
+struct test1 {
     key1 = "value"
     key2 = 1.342    # test comment here
     key3 = 10
     f = "none"
     var_ref = $(test2.inner.pair)
-end test1
+}
 
-struct test2
+struct test2 {
     my_key = "foo"
     n_key = 1
 
-    struct inner
+    struct inner {
       key = 1
       pair = "two"
       val = 1.232e10
       expression = {{ 0.5 * ($(test1.key2) - $(test2.inner.val)) }}
-    end inner
-end test2
+    }
+}

--- a/examples/config_example3.cfg
+++ b/examples/config_example3.cfg
@@ -1,30 +1,30 @@
-struct test1
+struct test1 {
     key1 = "value"
     key2 = 1.342    # test comment here
     key3 = 10
     f = "none"
-end test1
+}
 
-struct outer
+struct outer {
     my_key = "foo"
     var_ref = $(outer.inner.test1.key)
     n_key = 1
 
-    struct inner   # Another comment "here"
+    struct inner {   # Another comment "here"
       key = 1
       #pair = "two"
       val = 1.232e10
 
-      struct test1
+      struct test1 {
         key = -5
-      end test1
+      }
 
 # this comment isn't aligned, but works.
 
-    end inner
-end outer
+    }
+}
 
-struct test1
+struct test1 {
     different = 1
     other = 2
-end test1
+}

--- a/examples/config_example4.cfg
+++ b/examples/config_example4.cfg
@@ -1,61 +1,61 @@
 a_top_level_flat_key = -3429
 
-struct test1
+struct test1 {
     key1 = "value"
     key2 = 1.342    # test comment here
     key3 = 10
     f = "none"
-end test1
+}
 
-struct protos
-  proto joint_proto
+struct protos {
+  proto joint_proto   {
     key1 = $VAR1
     key2 = {{ 0.5 * ($MAX - ${MIN}) }}
     not_a_var = 27
     ref_var = $(ref_in_struct.hx.add_another)  # This one is tricky!
-  end joint_proto
+  }
 
   # Another comment here!
 
-end protos
+}
 
 
-struct outer
+struct outer   {
     my_key = "foo"
     n_key = 1
 
-    struct inner   # Another comment "here"
+    struct inner  {   # Another comment "here"
       key = 1
       #pair = "two"
       val = 1.232e10
 
-      struct test1
+      struct test1  {
         key = -5
-      end test1
-    end inner
-end outer
+      }
+    }
+}
 
-struct ref_in_struct
+struct ref_in_struct {
   key1 = -0.3492
 
-  reference protos.joint_proto as hx
+  reference protos.joint_proto as hx   {
     $VAR1 = "0xdeadbeef"
     $MAX =  0.67
     $MIN = -0.23
     +new_var = 5
     +add_another = -3.14159
-  end hx
+  }
 
 #  reference protos.joint_proto as commented
 #    dummy_key = 0
 #     $VAR1 = 0
 #  end commented
 
-end ref_in_struct
+}
 
-struct test1
+struct test1   {
     different = 1
     other = 2
-end test1
+}
 
 

--- a/examples/config_example5.cfg
+++ b/examples/config_example5.cfg
@@ -2,49 +2,49 @@
 
 include config_example6.cfg
 
-struct protos
+struct protos {
 
-    proto joint_proto
+    proto joint_proto {
       leg = $LEG
       dof = "${LEG}.$DOF"  # An example of using variables in a string
-    end joint_proto
+    }
 
-    proto leg_proto
+    proto leg_proto {
       key_1 = "foo"
       key_2 = "bar"
       key_3 = $LEG
 
-      reference protos.joint_proto as hx  # Can we make the 'hx' here be represented by $DOF?
+      reference protos.joint_proto as hx  {  # Can we make the 'hx' here be represented by $DOF?
         $DOF = "hx"
         +extra_key = 1.e-3
-      end hx
-    end leg_proto
-end protos
+      }
+    }
+}
 
-struct outer
+struct outer   {
     my_key = "foo"
     n_key = 1
     var_ref = $(outer.fl.key_3)
 
-    struct inner   # Another comment "here"
+    struct inner {   # Another comment "here"
       key = 1
       #pair = "two"
       val = 1.232e10
 
-      struct test1
+      struct test1   {
         key = [-0.123, 1.23e2, 0.123] # -5
-      end test1
+      }
 
       key_after = 3
-    end inner
+    }
 
     key_between = 4
 
-    reference protos.leg_proto as fl
+    reference protos.leg_proto as fl {
       $LEG = "fl"
       $DOF = "hx"
-    end fl
-end outer
+    }
+}
 
 
 

--- a/examples/config_example7.cfg
+++ b/examples/config_example7.cfg
@@ -1,54 +1,50 @@
 
-
 include config_example6.cfg
 
-struct protos
+struct protos {
 
-    proto joint_proto
+    proto joint_proto {
       leg = $LEG
       dof = "${LEG}.$DOF"  # An example of using variables in a string
 
-      struct nested_w_var
+      struct nested_w_var {
         my_value = $VALUE_IN_STRUCT
-      end nested_w_var
-    end joint_proto
+      }
+    }
 
-    proto leg_proto
+    proto leg_proto {
       key_1 = "foo"
       key_2 = "bar"
       key_3 = $LEG
 
-      reference protos.joint_proto as hx  # Can we make the 'hx' here be represented by $DOF?
+      reference protos.joint_proto as hx {  # Can we make the 'hx' here be represented by $DOF?
         +extra_key = 1.e-3
-      end hx
-    end leg_proto
-end protos
+      }
+    }
+}
 
-struct outer
+struct outer {
     my_key = "foo"
     n_key = 1
     var_ref = $(outer.fl.key_3)
 
-    struct inner   # Another comment "here"
+    struct inner  {   # Another comment "here"
       key = 1
       #pair = "two"
       val = 1.232e10
 
-      struct test1
+      struct test1  {
         key = [-0.123, 1.23e2, 0.123] # -5
-      end test1
+      }
 
       key_after = 3
-    end inner
+    }
 
     key_between = 4
 
-    reference protos.leg_proto as fl
+    reference protos.leg_proto as fl {
       $LEG = "fl"
       $DOF = "hx"
       $VALUE_IN_STRUCT = 3.14159
-    end fl
-end outer
-
-
-
+    }
+}

--- a/examples/config_example8.cfg
+++ b/examples/config_example8.cfg
@@ -3,39 +3,39 @@
 # twice. When resolving `joint1` and `joint2`, the `joint_proto` variables should resolve
 # differently. There was a bug that caused the variables from `joint1` to be used for `joint2`.
 
-struct protos
-  proto joint_proto
+struct protos {
+  proto joint_proto {
     key1 = $VAR1
     key2 = $VAR2
     not_a_var = 27
     ref_var = $(concrete.leg1.$VAR1)  # This one is tricky!
-  end joint_proto
+  }
 
   # Another comment here!
 
-  proto leg_proto
+  proto leg_proto {
     key_a = $KEY_A
     key_b = $KEY_B
 
-    reference protos.joint_proto as joint1
+    reference protos.joint_proto as joint1 {
       $VAR1 = "joint1.key1"
       $VAR2 = "joint1.var2"
-    end joint1
+    }
 
-    reference protos.joint_proto as joint2
+    reference protos.joint_proto as joint2 {
       $VAR1 = "joint2.key1"
       $VAR2 = "joint2.var2"
-    end joint2
-  end leg_proto
+    }
+  }
 
-end protos
+}
 
-struct concrete
+struct concrete {
 
-  reference protos.leg_proto as leg1
+  reference protos.leg_proto as leg1   {
     +add_key1 = 0
     $KEY_A = "leg1.key_a"
     $KEY_B = "leg1.key_b"
-  end leg1
+  }
 
-end concrete
+}

--- a/examples/invalid/config_cyclic1.cfg
+++ b/examples/invalid/config_cyclic1.cfg
@@ -1,20 +1,20 @@
 
-struct test2
+struct test2 {
     key1 = "value"
     key2 = 1.342    # test comment here
     key3 = $(test1.var_ref)  # This is part of a cyclic reference
     f = ["foo", "bar", "baz"]
-end test2
+}
 
-struct test1
+struct test1 {
     my_key = "foo"
     n_key = 0x1234
     var_ref = $(test3.cycle)  # This is part of a cyclic reference
-end test1
+}
 
-struct test3
+struct test3 {
     cycle = $(test2.key3)  # This is part of a cyclic reference
     no_cycle = 3.0
-end test3
+}
 
 solo_key  =     $(test3.cycle)

--- a/examples/invalid/config_cyclic2.cfg
+++ b/examples/invalid/config_cyclic2.cfg
@@ -1,26 +1,26 @@
 
-struct protos
-  proto joint_proto
+struct protos {
+  proto joint_proto {
     key1 = $VAR1
     key2 = $VAR2
     not_a_var = 27
 
-    reference protos.joint_proto as loop # Reference loop
+    reference protos.joint_proto as loop {  # Reference loop
       $VAR1 = 0
       $VAR2 = 1
-    end loop
+    }
 
-  end joint_proto
-end protos
+  }
+}
 
-struct ref_in_struct
+struct ref_in_struct {
   key1 = -0.3492
 
-  reference protos.joint_proto as hx
+  reference protos.joint_proto as hx {
     $VAR1 = "0xdeadbeef"
     $VAR2 = "3"
     +new_var = 5
     +add_another = -3.14159
-  end hx
+  }
 
-end ref_in_struct
+}

--- a/tests/config_grammar_test.cpp
+++ b/tests/config_grammar_test.cpp
@@ -364,7 +364,8 @@ TEST(config_grammar, KEY) {
 
   auto failKey = [](const std::string& input) {
     std::optional<RetType> ret;
-    EXPECT_THROW(ret.emplace(runTest<peg::must<config::KEY, peg::eolf>>(input)), std::exception);
+    EXPECT_THROW(ret.emplace(runTest<peg::must<config::KEY, peg::eolf>>(input)), std::exception)
+        << "Input key: " << input;
   };
 
   {
@@ -399,7 +400,7 @@ TEST(config_grammar, KEY) {
   }
   {
     // These will fail due to being reserved keywords
-    const std::vector<std::string> invalid = {"struct", "proto", "reference", "as", "end"};
+    const std::vector<std::string> invalid = {"struct", "proto", "reference", "as"};
     for (const auto& content : invalid) {
       failKey(content);
     }

--- a/tests/config_parse_test.cpp
+++ b/tests/config_parse_test.cpp
@@ -45,17 +45,17 @@ TEST_P(InputString, ConfigReaderParse) {
 }
 
 INSTANTIATE_TEST_SUITE_P(ConfigParse, InputString, testing::Values(std::string("\n\
-struct test1\n\
+struct test1 {\n\
     key1 = \"value\"\n\
     key2 = 1.342    # test comment here\n\
     key3 = 10\n\
     f = \"none\"\n\
-end test1\n\
+}\n\
 \n\
-struct test2\n\
+struct test2 {\n\
     my_key = \"foo\"  \n\
     n_key = 1\n\
-end test2\n\
+}\n\
 ")));
 
 /// File-based input


### PR DESCRIPTION
*  Drops the `end <KEY>` in favor of curly-brace enclosed content.