### PR TITLE
Further consolidates math grammar

### DIFF
--- a/cpp/config_grammar.h
+++ b/cpp/config_grammar.h
@@ -75,12 +75,16 @@ struct SP : peg::plus<peg::blank> {};
 struct oSP : peg::star<peg::blank> {};
 struct COMMENT : peg::seq<peg::one<'#'>, peg::until<peg::eol>, WS_> {};
 struct TAIL : peg::seq<WS_, peg::star<COMMENT>> {};
-struct COMMA : peg::pad<peg::one<','>, peg::blank> {};
-struct SBo : peg::pad<peg::one<'['>, peg::blank> {};
-struct SBc : peg::pad<peg::one<']'>, peg::blank> {};
-struct CBo : peg::pad<peg::one<'{'>, peg::blank> {};
-struct CBc : peg::pad<peg::one<'}'>, peg::blank> {};
-struct KVs : peg::pad<peg::one<'='>, peg::blank> {};
+// A rule for padding another rule with blanks on either side
+template <typename Rule>
+struct pd : peg::pad<Rule, peg::blank> {};
+
+struct COMMA : pd<peg::one<','>> {};
+struct SBo : pd<peg::one<'['>> {};
+struct SBc : pd<peg::one<']'>> {};
+struct CBo : pd<peg::one<'{'>> {};
+struct CBc : pd<peg::one<'}'>> {};
+struct KVs : pd<peg::one<'='>> {};
 
 struct STRUCTk : TAO_PEGTL_KEYWORD("struct") {};
 struct PROTOk : TAO_PEGTL_KEYWORD("proto") {};
@@ -129,7 +133,7 @@ struct VAR : peg::seq<peg::one<'$'>, peg::sor<peg::seq<peg::one<'{'>, VARc, peg:
 struct VAR_REF : peg::seq<TAO_PEGTL_STRING("$("), peg::list<peg::sor<KEY, VAR>, peg::one<'.'>>,
                           peg::one<')'>> {};
 
-struct REF_VARADD : peg::seq<peg::one<'+'>, KEY, KVs, VALUE, TAIL> {};
+struct REF_VARADD : peg::seq<peg::one<'+'>, KEY, KVs, peg::sor<VALUE, VAR_REF>, TAIL> {};
 struct REF_VARSUB : peg::seq<VAR, KVs, peg::sor<VALUE, VAR_REF>, TAIL> {};
 
 struct FULLPAIR : peg::seq<FLAT_KEY, KVs, peg::sor<VALUE, VAR_REF>, TAIL> {};

--- a/cpp/math_actions.h
+++ b/cpp/math_actions.h
@@ -192,8 +192,6 @@ struct stacks {
   std::vector<stack> s_;
 };
 
-}  // namespace math
-
 struct ActionData {
   math::stacks s;
 
@@ -203,7 +201,9 @@ struct ActionData {
   double res;  // The final result of the computation.
 };
 
-namespace grammar1 {
+}  // namespace math
+
+namespace math {
 
 template <typename Rule>
 struct action : peg::nothing<Rule> {};
@@ -252,10 +252,10 @@ struct action<expression> {
     // The top-most stack is automatically "finished" when leaving a bracketed operation. The
     // `expression` rule is also contained within a bracketed operation, but is also the terminal
     // rule, so we only want to call `finish` when not within brackets.
-    logger::warn("In expression action.");
+    logger::info(" !!! In expression action !!!");
     if (out.bracket_cnt == 0) {
       out.s.dump();
-      logger::info("Finishing!");
+      logger::info(" !!!  Finishing  !!!");
       out.res = out.s.finish();
       out.s.dump();
     }
@@ -272,7 +272,7 @@ struct action<Bo> {
   }
 };
 
-}  // namespace grammar1
+}  // namespace math
 
 namespace grammar2 {
 
@@ -280,65 +280,29 @@ template <typename Rule>
 struct action : peg::nothing<Rule> {};
 
 template <>
-struct action<v> {
-  template <typename ActionInput>
-  static void apply(const ActionInput& in, ActionData& out) {
-    out.s.push(std::stod(in.string()));
-  }
-};
+struct action<math::v> : math::action<math::v> {};
 
 template <>
-struct action<pi> {
-  static void apply0(ActionData& out) { out.s.push(M_PI); }
-};
+struct action<math::pi> : math::action<math::pi> {};
 
 template <>
-struct action<Um> {
-  static void apply0(ActionData& out) {
-    // Cheeky trick to support unary minus operator. Sneaky but simple!
-    out.s.push(-1);  // This value doesn't matter. It is ignored by the unary-minus operator
-    out.s.push("m");
-  }
-};
+struct action<math::Um> : math::action<math::Um> {};
 
 template <>
-struct action<Po> {
-  static void apply0(ActionData& out) {
-    out.s.open();
-    out.bracket_cnt++;
-  }
-};
+struct action<math::Po> : math::action<math::Po> {};
 
 template <>
-struct action<Pc> {
-  static void apply0(ActionData& out) {
-    out.s.close();
-    out.bracket_cnt--;
-  }
-};
+struct action<math::Pc> : math::action<math::Pc> {};
 
 template <>
-struct action<expression> {
-  static void apply0(ActionData& out) {
-    // The top-most stack is automatically "finished" when leaving a bracketed operation. The
-    // `expression` rule is also contained within a bracketed operation, but is also the terminal
-    // rule, so we only want to call `finish` when not within brackets.
-    logger::warn("In expression action.");
-    if (out.bracket_cnt == 0) {
-      out.s.dump();
-      logger::info("Finishing!");
-      out.res = out.s.finish();
-      out.s.dump();
-    }
-  }
-};
+struct action<expression> : math::action<math::expression> {};
 
 /// Everything above here is common to both grammars. Everything below exclusive to this one.
 
 template <>
 struct action<PM> {
   template <typename ActionInput>
-  static void apply(const ActionInput& in, ActionData& out) {
+  static void apply(const ActionInput& in, math::ActionData& out) {
     out.s.push(in.string());
   }
 };
@@ -346,35 +310,35 @@ struct action<PM> {
 template <>
 struct action<MD> {
   template <typename ActionInput>
-  static void apply(const ActionInput& in, ActionData& out) {
+  static void apply(const ActionInput& in, math::ActionData& out) {
     out.s.push(in.string());
   }
 };
 
 template <>
-struct action<Bpow> {
+struct action<math::Bpow> {
   template <typename ActionInput>
-  static void apply(const ActionInput& in, ActionData& out) {
+  static void apply(const ActionInput& in, math::ActionData& out) {
     logger::warn("Found {}!", in.string());
     out.s.push(in.string());
   }
 };
 
 // These are no-ops. They're only part of the grammar in order to build the AST, but not actually
-// functional in performing the math.
+// functional in performing the math. We include them here for tracing purposes only.
 template <>
 struct action<T> {
-  static void apply0(ActionData& out) { logger::warn("In T action"); }
+  static void apply0(math::ActionData& out) { logger::debug(" --- In T action"); }
 };
 
 template <>
 struct action<F> {
-  static void apply0(ActionData& out) { logger::warn("In F action"); };
+  static void apply0(math::ActionData& out) { logger::debug(" --- In F action"); };
 };
 
 template <>
 struct action<P> {
-  static void apply0(ActionData& out) { logger::warn("In P action"); };
+  static void apply0(math::ActionData& out) { logger::debug(" --- In P action"); };
 };
 
 }  // namespace grammar2

--- a/tests/math_test.cpp
+++ b/tests/math_test.cpp
@@ -17,66 +17,54 @@ namespace peg = TAO_PEGTL_NAMESPACE;
 
 namespace {
 const std::vector<std::pair<std::string, double>> test_strings = {
-    {"3.14159 * 1e3", 3141.5899999999997},
-    {"0.5 * (0.7 + 1.2)", 0.95},
-    {"0.5 + 0.7 * 1.2", 1.3399999999999999},
-    {"3*0.27 - 2.3**0.5 - 5*4", -20.70657508881031},
-    {"3 ^ 2.4 * 12.2 + 0.1 + 4.3 ", 174.79264401590646},
-    {"-4.7 * -(3.72 + -pi)", 2.7185145281279732},
-    {"1/3 * -(5 + 4)", -3.0},
-    {"3.4 * -(1.9**2 * (1/3.1 - 6) * (2.54- 17.0))", -1007.6399690322581}};
+    // Inject some whitespace to test robustness to it.
+    {" 3.14159 * 1e3", 3141.5899999999997},
+    {"0.5 *  (0.7 + 1.2 ) ", 0.95},
+    {"0.5 + 0.7 * 1.2     ", 1.3399999999999999},
+    {"3*0.27 - 2.3**0.5 - 5 * 4", -20.70657508881031},
+    {"  3 ^ 2.4 * 12.2 + 0.1 + 4.3 ", 174.79264401590646},
+    {"-4.7 * -(3.72 + -pi  ) ", 2.7185145281279732},
+    {"  1/3 * -( 5 + 4 )  ", -3.0},
+    {"\t3.4 * -(1.9**2 * (1/3.1 - 6) * (2.54- 17.0)\t)", -1007.6399690322581}};
 }
 
-TEST(math_expression, grammar1_analyze) {
-  namespace math = grammar1;
-  ASSERT_EQ(peg::analyze<math::expression>(), 0);
-
-  struct grammar : peg::seq<Mo, math::expression, Mc> {};
-  ASSERT_EQ(peg::analyze<grammar>(), 0);
-}
+TEST(math_expression, analyze) { ASSERT_EQ(peg::analyze<math::expression>(), 0); }
 
 TEST(math_expression, grammar2_analyze) {
   namespace math = grammar2;
   ASSERT_EQ(peg::analyze<math::expression>(), 0);
-
-  struct grammar : peg::seq<Mo, math::expression, Mc> {};
-  ASSERT_EQ(peg::analyze<grammar>(), 0);
 }
 
-TEST(math_expression, grammar1_evaluate) {
-  namespace math = grammar1;
-  struct grammar : peg::seq<Mo, math::expression, Mc> {};
-
+TEST(math_expression, evaluate) {
   auto test_input = [](const std::string& input) -> double {
     peg::memory_input in(input, "from content");
-    ActionData out;
-    const auto result = peg::parse<grammar, math::action>(in, out);
+    math::ActionData out;
+    const auto result = peg::parse<math::expression, math::action>(in, out);
     return out.res;
   };
 
   for (const auto& input : test_strings) {
     std::cout << "Input: " << input.first << std::endl;
     double result{0};
-    EXPECT_NO_THROW(result = test_input(" {{  " + input.first + "   }}"));
+    EXPECT_NO_THROW(result = test_input(input.first));
     EXPECT_FLOAT_EQ(result, input.second);
   }
 }
 
 TEST(math_expression, grammar2_evaluate) {
   namespace math = grammar2;
-  struct grammar : peg::seq<Mo, math::expression, Mc> {};
 
   auto test_input = [](const std::string& input) -> double {
     peg::memory_input in(input, "from content");
-    ActionData out;
-    const auto result = peg::parse<grammar, math::action>(in, out);
+    ::math::ActionData out;
+    const auto result = peg::parse<math::expression, math::action>(in, out);
     return out.res;
   };
 
   for (const auto& input : test_strings) {
     std::cout << "Input: " << input.first << std::endl;
     double result{0};
-    EXPECT_NO_THROW(result = test_input(" {{  " + input.first + "   }}"));
+    EXPECT_NO_THROW(result = test_input(input.first));
     EXPECT_FLOAT_EQ(result, input.second);
   }
 }


### PR DESCRIPTION
*  Moves ActionData used for `math` into math namespace.
*  Moves common grammar rules from math_grammar.h into `math` namespace.
*  Eliminate duplicate actions in `grammar2` namespace by inheriting
   from actions in math namespace.