### PR TITLE
Allows reference name to be assigned to variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ The above example introduces the following concepts:
 3. `+extra_key` is an appended key. The `proto` "protos.foo" does not contain this key, but the resulting `struct fuzz`
    will contain this additional key.
 
+NOTE: There is a special variable `$PARENT_NAME` which can be used to assign the value of the containing parent key to a variable defined in a proto (e.g. we could write `$KEY3 = $PARENT_NAME` which would assign the value `"fuzz"` to `$KEY3`).
+
 The above `reference` could be defined as follows using the `struct` syntax:
 
 ```

--- a/cpp/config_actions.h
+++ b/cpp/config_actions.h
@@ -250,6 +250,17 @@ struct action<VAR> {
 };
 
 template <>
+struct action<PARENTNAMEk> {
+  static void apply0(ActionData& out) {
+    // When this action is invoked, we create a ConfigValue (of type kString) whose value matches
+    // the name/key of the parent object. This allows us to easily reference the name of the parent
+    // object where required.
+    out.obj_res =
+        std::make_shared<types::ConfigValue>(out.objects.back()->name, types::Type::kString);
+  }
+};
+
+template <>
 struct action<filename::FILENAME> {
   template <typename ActionInput>
   static void apply(const ActionInput& in, ActionData& out) {

--- a/cpp/config_grammar.h
+++ b/cpp/config_grammar.h
@@ -98,6 +98,7 @@ struct STRUCTk : TAO_PEGTL_KEYWORD("struct") {};
 struct PROTOk : TAO_PEGTL_KEYWORD("proto") {};
 struct REFk : TAO_PEGTL_KEYWORD("reference") {};
 struct ASk : TAO_PEGTL_KEYWORD("as") {};
+struct PARENTNAMEk : TAO_PEGTL_KEYWORD("$PARENT_NAME") {};
 
 struct RESERVED : peg::sor<STRUCTk, PROTOk, REFk, ASk> {};
 
@@ -144,7 +145,7 @@ struct VAR_REF : peg::seq<TAO_PEGTL_STRING("$("), peg::list<peg::sor<KEY, VAR>, 
 
 struct REF_VARADD : peg::seq<peg::one<'+'>, KEY, KVs, peg::sor<VALUE, VAR_REF, EXPRESSION>, TAIL> {
 };
-struct REF_VARSUB : peg::seq<VAR, KVs, peg::sor<VALUE, VAR_REF, EXPRESSION>, TAIL> {};
+struct REF_VARSUB : peg::seq<VAR, KVs, peg::sor<VALUE, VAR_REF, EXPRESSION, PARENTNAMEk>, TAIL> {};
 
 struct FULLPAIR : peg::seq<FLAT_KEY, KVs, peg::sor<VALUE, VAR_REF, EXPRESSION>, TAIL> {};
 struct PAIR : peg::seq<KEY, KVs, peg::sor<VALUE, VAR_REF, EXPRESSION>, TAIL> {};


### PR DESCRIPTION
*  A reference key/name may be assigned to a variable via the special
   keyword `$PARENT_NAME`. See `README.md` for details.

Addresses #41