### PR TITLE
Addresses additional clang-tidy warnings

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -9,6 +9,7 @@ Checks: '-*,
 				 -bugprone-easily-swappable-parameters,
 				 cert-*,
 				 hicpp-*,
+				 -hicpp-avoid-goto,
 				 modernize-*,
 				 performance-*,
 				 readability-*
@@ -17,3 +18,6 @@ Checks: '-*,
 HeaderFilterRegex: 'cpp/.*'
 
 #WarningsAsErrors: '*'
+
+CheckOptions:
+  - { key: readability-function-cognitive-complexity.IgnoreMacros,     value: 1 }

--- a/cpp/config_build.cpp
+++ b/cpp/config_build.cpp
@@ -1,3 +1,7 @@
+#include <fmt/color.h>
+#include <fmt/format.h>
+
+#include <exception>
 #include <filesystem>
 #include <magic_enum.hpp>
 #include <span>
@@ -6,28 +10,33 @@
 #include "logger.h"
 
 auto main(int argc, char* argv[]) -> int {
-  std::span<char*> args(argv, argc);
-  if (argc < 2) {
-    std::cerr << "No file specified.\n";
-    std::cerr << "usage: " << std::filesystem::path(args[0]).filename().string() << " CFG_FILE"
-              << std::endl;
-    return -1;
-  }
-  logger::Severity log_level = logger::Severity::INFO;
-  if (argc == 3) {
-    auto out = magic_enum::enum_cast<logger::Severity>(args[2]);
-    if (out.has_value()) {
-      log_level = out.value();
+  try {
+    std::span<char*> args(argv, argc);
+    if (argc < 2) {
+      std::cerr << "No file specified.\n";
+      std::cerr << "usage: " << std::filesystem::path(args[0]).filename().string() << " CFG_FILE"
+                << std::endl;
+      return -1;
     }
-  }
-  logger::setLevel(log_level);
+    logger::Severity log_level = logger::Severity::INFO;
+    if (argc == 3) {
+      auto out = magic_enum::enum_cast<logger::Severity>(args[2]);
+      if (out.has_value()) {
+        log_level = out.value();
+      }
+    }
+    logger::setLevel(log_level);
 
-  ConfigReader cfg;
-  const auto success = cfg.parse(std::filesystem::path(args[1]));
-  if (success) {
-    std::cout << std::endl;
-    cfg.dump();
-  }
+    ConfigReader cfg;
+    const auto success = cfg.parse(std::filesystem::path(args[1]));
+    if (success) {
+      std::cout << std::endl;
+      cfg.dump();
+    }
 
-  return (success ? 0 : 1);
+    return (success ? EXIT_SUCCESS : EXIT_FAILURE);
+  } catch (const std::exception& e) {
+    fmt::print(fmt::fg(fmt::color::red), "{}\n", e.what());
+    return EXIT_FAILURE;
+  }
 }

--- a/cpp/config_reader_example.cpp
+++ b/cpp/config_reader_example.cpp
@@ -1,5 +1,6 @@
 // Read a configuration file and get values from it.
 
+#include <fmt/color.h>
 #include <fmt/format.h>
 
 #include <array>
@@ -13,74 +14,79 @@
 #include "logger.h"
 
 auto main(int argc, char* argv[]) -> int {
-  const auto cfg_file = std::filesystem::path(EXAMPLE_DIR) / "config_example5.cfg";
+  try {
+    const auto cfg_file = std::filesystem::path(EXAMPLE_DIR) / "config_example5.cfg";
 
-  ConfigReader cfg;
-  if (!cfg.parse(cfg_file)) {
-    logger::error("Failed to parse {}", cfg_file.string());
-  }
-
-  logger::setLevel(logger::Severity::INFO);
-
-  std::cout << std::endl;
-  // Read a variety of values from the config file (and print their values).
-  {
-    const std::string int_key = "outer.inner.key";
-    const auto out = cfg.getValue<int>(int_key);
-    fmt::print("Value of '{}' is: {}\n", int_key, out);
-  }
-  {
-    // getValue to return a value, or it can take a reference to a value:
-    const std::string float_key = "outer.fl.hx.extra_key";
-    auto out = cfg.getValue<float>(float_key);
-    fmt::print("Value of '{}' is: {}\n", float_key, out);
-    // This is the same as the above
-    cfg.getValue(float_key, out);
-    fmt::print("Value of '{}' is: {}\n", float_key, out);
-
-    // Similarly, this value can be read as a float or a double. It doesn't really matter.
-    auto out_d = cfg.getValue<double>(float_key);
-    fmt::print("Value of '{}' as a double is: {}\n", float_key, out_d);
-
-    // It however, cannot be read as an integer type!
-    try {
-      auto out_i = cfg.getValue<int>(float_key);
-      fmt::print("Value of '{}' as an int is: {}\n", float_key, out_i);
-    } catch (config::MismatchTypeException& e) {
-      logger::error("!!! getValue failure !!!\n{}", e.what());
+    ConfigReader cfg;
+    if (!cfg.parse(cfg_file)) {
+      logger::error("Failed to parse {}", cfg_file.string());
     }
-  }
-  {
-    // Vectors of values can also be read.
-    const std::string vec_key = "outer.inner.test1.key";
-    auto var = cfg.getValue<std::vector<float>>(vec_key);
-    fmt::print("Value of '{}' is: {}\n", vec_key, var);
-    // Just as with scalar values, passing by reference works for vectors.
-    cfg.getValue(vec_key, var);
-    fmt::print("Value of '{}' is: {}\n", vec_key, var);
 
-    // This same entry can be read using a std::array, which provides length checking.
-    // E.g. This will pass:
-    auto arr_var = cfg.getValue<std::array<float, 3>>(vec_key);
-    fmt::print("Value of array '{}' is: {}\n", vec_key, arr_var);
-    // But this will fail:
-    try {
-      // There are only 3 values contained by the key, but we're looking for 4!
-      auto arr_var = cfg.getValue<std::array<float, 4>>(vec_key);
-      logger::info("Value of {} is {}", vec_key, arr_var);
-    } catch (std::exception& e) {
-      logger::error("!!! getValue failure !!!\n{}", e.what());
+    logger::setLevel(logger::Severity::INFO);
+
+    std::cout << std::endl;
+    // Read a variety of values from the config file (and print their values).
+    {
+      const std::string int_key = "outer.inner.key";
+      const auto out = cfg.getValue<int>(int_key);
+      fmt::print("Value of '{}' is: {}\n", int_key, out);
     }
-  }
-  {
-    const std::string int_key = "a_top_level_flat_key";
-    const auto out = cfg.getValue<int>(int_key);
-    fmt::print("Value of '{}' is: {}\n", int_key, out);
+    {
+      // getValue to return a value, or it can take a reference to a value:
+      const std::string float_key = "outer.fl.hx.extra_key";
+      auto out = cfg.getValue<float>(float_key);
+      fmt::print("Value of '{}' is: {}\n", float_key, out);
+      // This is the same as the above
+      cfg.getValue(float_key, out);
+      fmt::print("Value of '{}' is: {}\n", float_key, out);
 
-    // TODO: Decide if we should allow this or if it should be a failure.
-    const auto out_f = cfg.getValue<float>(int_key);
-    fmt::print("Value of '{}' is: {}\n", int_key, out_f);
+      // Similarly, this value can be read as a float or a double. It doesn't really matter.
+      auto out_d = cfg.getValue<double>(float_key);
+      fmt::print("Value of '{}' as a double is: {}\n", float_key, out_d);
+
+      // It however, cannot be read as an integer type!
+      try {
+        auto out_i = cfg.getValue<int>(float_key);
+        fmt::print("Value of '{}' as an int is: {}\n", float_key, out_i);
+      } catch (config::MismatchTypeException& e) {
+        logger::error("!!! getValue failure !!!\n{}", e.what());
+      }
+    }
+    {
+      // Vectors of values can also be read.
+      const std::string vec_key = "outer.inner.test1.key";
+      auto var = cfg.getValue<std::vector<float>>(vec_key);
+      fmt::print("Value of '{}' is: {}\n", vec_key, var);
+      // Just as with scalar values, passing by reference works for vectors.
+      cfg.getValue(vec_key, var);
+      fmt::print("Value of '{}' is: {}\n", vec_key, var);
+
+      // This same entry can be read using a std::array, which provides length checking.
+      // E.g. This will pass:
+      auto arr_var = cfg.getValue<std::array<float, 3>>(vec_key);
+      fmt::print("Value of array '{}' is: {}\n", vec_key, arr_var);
+      // But this will fail:
+      try {
+        // There are only 3 values contained by the key, but we're looking for 4!
+        auto arr_var = cfg.getValue<std::array<float, 4>>(vec_key);
+        logger::info("Value of {} is {}", vec_key, arr_var);
+      } catch (std::exception& e) {
+        logger::error("!!! getValue failure !!!\n{}", e.what());
+      }
+    }
+    {
+      const std::string int_key = "a_top_level_flat_key";
+      const auto out = cfg.getValue<int>(int_key);
+      fmt::print("Value of '{}' is: {}\n", int_key, out);
+
+      // TODO: Decide if we should allow this or if it should be a failure.
+      const auto out_f = cfg.getValue<float>(int_key);
+      fmt::print("Value of '{}' is: {}\n", int_key, out_f);
+    }
+  } catch (const std::exception& e) {
+    fmt::print(fmt::fg(fmt::color::red), "{}\n", e.what());
+    return EXIT_FAILURE;
   }
 
-  return 0;
+  return EXIT_SUCCESS;
 }

--- a/cpp/config_selector.h
+++ b/cpp/config_selector.h
@@ -23,7 +23,7 @@ struct selector<INCLUDE> : std::true_type {
   template <typename... States>
   static void transform(std::unique_ptr<peg::parse_tree::node>& n, States&&... st) {
     logger::info("Successfully found a {} node in {}!", n->type, n->source);
-    std::string filename = "";
+    std::string filename{};
     for (const auto& c : n->children) {
       logger::debug("Has child of type {}.", c->type);
       if (c->has_content()) {

--- a/cpp/math_actions.h
+++ b/cpp/math_actions.h
@@ -39,10 +39,7 @@ struct ActionData {
   double res{};  // The final result of the computation.
 };
 
-}  // namespace math
-
-namespace math {
-
+/* Actions */
 template <typename Rule>
 struct action : peg::nothing<Rule> {};
 
@@ -64,7 +61,7 @@ struct action<Um> {
   static void apply0(ActionData& out) {
     // Cheeky trick to support unary minus operator. Sneaky but simple!
     out.s.push(-1);  // This value doesn't matter. It is ignored by the unary-minus operator
-    out.s.push("m");
+    out.s.push(std::string("m"));
   }
 };
 

--- a/tests/.clang-tidy
+++ b/tests/.clang-tidy
@@ -1,2 +1,0 @@
-Checks: '-*,
-         google-readability-todo'

--- a/tests/config_exception_test.cpp
+++ b/tests/config_exception_test.cpp
@@ -23,13 +23,14 @@ auto parse(INPUT& input) {
 }
 
 template <>
-auto parse(std::filesystem::path& in_file) {
-  peg::file_input cfg_file(in_file);
+auto parse(std::filesystem::path& input) {
+  peg::file_input cfg_file(input);
   return parse(cfg_file);
 }
 
 }  // namespace
 
+// NOLINTNEXTLINE
 TEST(config_exception_test, parse_error) {
   {
     const std::vector parse_error = {
@@ -46,11 +47,13 @@ TEST(config_exception_test, parse_error) {
          foo.bar = 1   # Can't mix flat keys with struct in same file."};
     for (const auto& input : parse_error) {
       peg::memory_input in_cfg(input, "From content");
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
       EXPECT_THROW(parse(in_cfg), peg::parse_error) << "Input file: " << in_cfg.source();
     }
   }
 }
 
+// NOLINTNEXTLINE
 TEST(config_exception_test, mismatched_key) {
   {
     const std::string_view mismatched_key =
@@ -59,10 +62,12 @@ TEST(config_exception_test, mismatched_key) {
           key = \"value\" \n\
         }  # This end key should match the 'struct' key, and will produce an exception.";
     peg::memory_input in_cfg(mismatched_key, "No trailing newline");
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
     EXPECT_THROW(parse(in_cfg), peg::parse_error) << "Input file: " << in_cfg.source();
   }
 }
 
+// NOLINTNEXTLINE
 TEST(config_exception_test, DuplicateKeyException) {
   {
     const std::string_view duplicate_in_struct =
@@ -72,6 +77,7 @@ TEST(config_exception_test, DuplicateKeyException) {
            key1 = -4   #  Duplicate key. This should produce an exception. \n\
          }\n";
     peg::memory_input in_cfg(duplicate_in_struct, "key1 defined twice");
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
     EXPECT_THROW(parse(in_cfg), config::DuplicateKeyException) << "Input file: " << in_cfg.source();
   }
   {
@@ -86,6 +92,7 @@ TEST(config_exception_test, DuplicateKeyException) {
            +bar = 0                     \n\
          }\n";
     ConfigReader cfg;
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
     EXPECT_THROW(cfg.parse(ref_proto_failure, "ref_proto_failure"), config::DuplicateKeyException);
   }
 #if 0  // See FULLPAIR action
@@ -95,6 +102,7 @@ TEST(config_exception_test, DuplicateKeyException) {
          another.key = -1.2         \n\
          this.is.a.key = \"again\"  \n";
     peg::memory_input in_cfg(duplicate_full_pair, "this.is.a.key defined twice");
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
     EXPECT_THROW(parse(in_cfg), config::DuplicateKeyException);
   }
 #endif
@@ -111,6 +119,7 @@ TEST(config_exception_test, DuplicateKeyException) {
            +bar = 0                     \n\
          }\n";
     peg::memory_input in_cfg(var_add_duplicate, "test2.bar defined twice");
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
     EXPECT_THROW(parse(in_cfg), config::DuplicateKeyException);
   }
   {
@@ -121,26 +130,31 @@ TEST(config_exception_test, DuplicateKeyException) {
            baz = $(duplicate.key)       \n\
          }\n";
     peg::memory_input in_cfg(proto_pair_duplicate, "proto_foo.baz defined twice");
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
     EXPECT_THROW(parse(in_cfg), config::DuplicateKeyException);
   }
 }
 
 namespace {
-const std::vector<std::string_view> struct_likes = {
-    "struct fizz {                \n\
-       buzz = \"buzz\"            \n\
-     }",
-    "reference bar as fizz {      \n\
-       $BUZZ = \"buzz\"           \n\
-     }",
-    "proto fizz {                 \n\
-       buzz = $BUZZ               \n\
-     }"};
+auto structLikes() -> const std::vector<std::string_view>& {
+  static const std::vector<std::string_view> struct_likes = {
+      "struct fizz {                \n\
+         buzz = \"buzz\"            \n\
+       }",
+      "reference bar as fizz {      \n\
+         $BUZZ = \"buzz\"           \n\
+       }",
+      "proto fizz {                 \n\
+         buzz = $BUZZ               \n\
+       }"};
+  return struct_likes;
 }
+}  // namespace
 
 class DuplicateKeys
     : public testing::TestWithParam<std::tuple<std::string_view, std::string_view>> {};
 
+// NOLINTNEXTLINE
 TEST_P(DuplicateKeys, Exception) {
   const std::string_view cfg_base =
       "struct foo {{                    \n\
@@ -156,13 +170,16 @@ TEST_P(DuplicateKeys, Exception) {
       cfg_base, fmt::make_format_args(std::get<0>(GetParam()), std::get<1>(GetParam())));
   // std::cout << "Test config: \n" << cfg << std::endl;
   peg::memory_input in_cfg(cfg, "duplicate 'fizz'");
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
   EXPECT_THROW(parse(in_cfg), config::DuplicateKeyException) << "Input config:\n" << cfg;
 }
 
+// NOLINTNEXTLINE
 INSTANTIATE_TEST_SUITE_P(config_exception_test, DuplicateKeys,
-                         testing::Combine(testing::ValuesIn(struct_likes),
-                                          testing::ValuesIn(struct_likes)));
+                         testing::Combine(testing::ValuesIn(structLikes()),
+                                          testing::ValuesIn(structLikes())));
 
+// NOLINTNEXTLINE
 TEST(config_exception_test, InvalidKeyException) {
   {
     const std::string_view invalid_key_reference =
@@ -171,6 +188,7 @@ TEST(config_exception_test, InvalidKeyException) {
            key = $(test1.key2)  \n\
          }\n";
     ConfigReader cfg;
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
     EXPECT_THROW(cfg.parse(invalid_key_reference, "invalid key reference"),
                  config::InvalidKeyException);
   }
@@ -182,10 +200,12 @@ TEST(config_exception_test, InvalidKeyException) {
            key = $(test1.key3.bar)  \n\
          }\n";
     ConfigReader cfg;
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
     EXPECT_THROW(cfg.parse(not_a_struct, "not a struct"), config::InvalidKeyException);
   }
 }
 
+// NOLINTNEXTLINE
 TEST(config_exception_test, InvalidTypeException) {
   {
     // This can also occur if the key exists but is of the wrong type
@@ -196,6 +216,7 @@ TEST(config_exception_test, InvalidTypeException) {
            key3 = 0                 \n\
          }\n";
     ConfigReader cfg;
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
     EXPECT_THROW(cfg.parse(key_wrong_type, "key wrong type"), config::InvalidTypeException);
   }
   {
@@ -205,11 +226,13 @@ TEST(config_exception_test, InvalidTypeException) {
            key2 = {{ 0.5 * $(foo.key1) }}  \n\
          }\n";
     ConfigReader cfg;
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
     EXPECT_THROW(cfg.parse(non_numeric_in_expression, "non numeric in expression"),
                  config::InvalidTypeException);
   }
 }
 
+// NOLINTNEXTLINE
 TEST(config_exception_test, UndefinedReferenceVarException) {
   {
     const std::string_view proto_var_doesnt_exist =
@@ -223,6 +246,7 @@ TEST(config_exception_test, UndefinedReferenceVarException) {
            #$KEY2 undefined            \n\
          }\n";
     ConfigReader cfg;
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
     EXPECT_THROW(cfg.parse(proto_var_doesnt_exist, "$KEY2 is undefined"),
                  config::UndefinedReferenceVarException);
   }
@@ -239,10 +263,12 @@ TEST(config_exception_test, UndefinedReferenceVarException) {
            $EXTRA_KEY = 0  # not useful, but not an error  \n\
          }\n";
     ConfigReader cfg;
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
     EXPECT_NO_THROW(cfg.parse(extra_proto_var, "$EXTRA_KEY is unused"));
   }
 }
 
+// NOLINTNEXTLINE
 TEST(config_exception_test, UndefinedProtoException) {
   {
     const std::string_view undefined_proto =
@@ -256,6 +282,7 @@ TEST(config_exception_test, UndefinedProtoException) {
            $KEY2 = \"defined\"                             \n\
          }\n";
     ConfigReader cfg;
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
     EXPECT_THROW(cfg.parse(undefined_proto, "bar_proto not defined"),
                  config::UndefinedProtoException);
   }
@@ -263,11 +290,14 @@ TEST(config_exception_test, UndefinedProtoException) {
 
 class CyclicReference : public testing::TestWithParam<std::string> {};
 
+// NOLINTNEXTLINE
 TEST_P(CyclicReference, Exception) {
   ConfigReader cfg;
   const auto in_file = std::filesystem::path(EXAMPLE_DIR) / "invalid" / GetParam();
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
   EXPECT_THROW(cfg.parse(in_file), config::CyclicReferenceException) << "Input file: " << in_file;
 }
 
+// NOLINTNEXTLINE
 INSTANTIATE_TEST_SUITE_P(config_exception_test, CyclicReference,
                          testing::Values("config_cyclic1.cfg", "config_cyclic2.cfg"));

--- a/tests/config_grammar_test.cpp
+++ b/tests/config_grammar_test.cpp
@@ -28,6 +28,7 @@ template <typename GRAMMAR, typename T>
 void checkResult(const std::string& input, config::types::Type expected_type,
                  std::optional<config::ActionData>& out) {
   std::optional<RetType> ret;
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
   ASSERT_NO_THROW(ret.emplace(runTest<GRAMMAR>(input)));
   ASSERT_TRUE(ret.has_value());
   ASSERT_TRUE(ret.value().first);
@@ -41,14 +42,17 @@ void checkResult(const std::string& input, config::types::Type expected_type,
 }
 }  // namespace
 
+// NOLINTNEXTLINE
 TEST(config_grammar, analyze) { ASSERT_EQ(peg::analyze<config::grammar>(), 0); }
 
+// NOLINTNEXTLINE
 TEST(config_grammar, INTEGER) {
   auto checkInt = [](const std::string& input) {
     std::optional<config::ActionData> out;
     checkResult<peg::must<config::INTEGER, peg::eolf>, config::types::ConfigValue>(
         input, config::types::Type::kNumber, out);
     const auto value = dynamic_pointer_cast<config::types::ConfigValue>(out->obj_res);
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
     ASSERT_NO_THROW(std::any_cast<int>(value->value_any));
     EXPECT_EQ(std::any_cast<int>(value->value_any), std::stoi(input));
   };
@@ -76,6 +80,7 @@ TEST(config_grammar, INTEGER) {
     // This should fail due to the leading zero.
     const std::string content = "0123";
     std::optional<RetType> ret;
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
     EXPECT_THROW(ret.emplace(runTest<peg::must<config::INTEGER, peg::eolf>>(content)),
                  std::exception);
   }
@@ -83,6 +88,7 @@ TEST(config_grammar, INTEGER) {
     // This should fail due to being a float.
     const std::string content = "12.3";
     std::optional<RetType> ret;
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
     EXPECT_THROW(ret.emplace(runTest<peg::must<config::INTEGER, peg::eolf>>(content)),
                  std::exception);
   }
@@ -90,17 +96,20 @@ TEST(config_grammar, INTEGER) {
     // This should fail due to being a float.
     const std::string content = "0.";
     std::optional<RetType> ret;
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
     EXPECT_THROW(ret.emplace(runTest<peg::must<config::INTEGER, peg::eolf>>(content)),
                  std::exception);
   }
 }
 
+// NOLINTNEXTLINE
 TEST(config_grammar, FLOAT) {
   auto checkFloat = [](const std::string& input) {
     std::optional<config::ActionData> out;
     checkResult<peg::must<config::FLOAT, peg::eolf>, config::types::ConfigValue>(
         input, config::types::Type::kNumber, out);
     const auto value = dynamic_pointer_cast<config::types::ConfigValue>(out->obj_res);
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
     ASSERT_NO_THROW(std::any_cast<double>(value->value_any));
     EXPECT_EQ(std::any_cast<double>(value->value_any), std::stod(input));
   };
@@ -160,6 +169,7 @@ TEST(config_grammar, FLOAT) {
     // This will fail due to the leading zero.
     std::string content = "01.23";
     std::optional<RetType> ret;
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
     EXPECT_THROW(ret.emplace(runTest<peg::must<config::FLOAT, peg::eolf>>(content)),
                  std::exception);
   }
@@ -167,6 +177,7 @@ TEST(config_grammar, FLOAT) {
     // This will fail due to being an integer
     std::string content = "123";
     std::optional<RetType> ret;
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
     EXPECT_THROW(ret.emplace(runTest<peg::must<config::FLOAT, peg::eolf>>(content)),
                  std::exception);
   }
@@ -174,6 +185,7 @@ TEST(config_grammar, FLOAT) {
     // This will fail due to the decimal valued exponent
     std::string content = "1.23e1.2";
     std::optional<RetType> ret;
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
     EXPECT_THROW(ret.emplace(runTest<peg::must<config::FLOAT, peg::eolf>>(content)),
                  std::exception);
   }
@@ -181,11 +193,13 @@ TEST(config_grammar, FLOAT) {
     // This will fail due to the exponent value missing.
     std::string content = "1.23e";
     std::optional<RetType> ret;
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
     EXPECT_THROW(ret.emplace(runTest<peg::must<config::FLOAT, peg::eolf>>(content)),
                  std::exception);
   }
 }
 
+// NOLINTNEXTLINE
 TEST(config_grammar, NUMBER) {
   auto checkNumber = [](const std::string& input) {
     std::optional<config::ActionData> out;
@@ -220,6 +234,7 @@ TEST(config_grammar, NUMBER) {
   }
 }
 
+// NOLINTNEXTLINE
 TEST(config_grammar, HEX) {
   auto checkHex = [](const std::string& input) {
     std::optional<config::ActionData> out;
@@ -250,22 +265,26 @@ TEST(config_grammar, HEX) {
     // This will fail due to an extra leading 0
     std::string content = "00x00";
     std::optional<RetType> ret;
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
     EXPECT_THROW(ret.emplace(runTest<peg::must<config::HEX, peg::eolf>>(content)), std::exception);
   }
   {
     // This will fail due to an alpha character not within the hexadecimal range
     std::string content = "0xG";
     std::optional<RetType> ret;
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
     EXPECT_THROW(ret.emplace(runTest<peg::must<config::HEX, peg::eolf>>(content)), std::exception);
   }
   {
     // This will fail due to a leading negative sign
     std::string content = "-0xd0D";
     std::optional<RetType> ret;
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
     EXPECT_THROW(ret.emplace(runTest<peg::must<config::HEX, peg::eolf>>(content)), std::exception);
   }
 }
 
+// NOLINTNEXTLINE
 TEST(config_grammar, STRING) {
   auto checkString = [](const std::string& input) {
     std::optional<config::ActionData> out;
@@ -300,6 +319,7 @@ TEST(config_grammar, STRING) {
     // This will fail due to a lack of trailing quote
     const std::string content = "\"test";
     std::optional<RetType> ret;
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
     EXPECT_THROW(ret.emplace(runTest<peg::must<config::STRING, peg::eolf>>(content)),
                  std::exception);
   }
@@ -307,22 +327,26 @@ TEST(config_grammar, STRING) {
     // This will fail due to a lack of leading quote
     const std::string content = "test\"";
     std::optional<RetType> ret;
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
     EXPECT_THROW(ret.emplace(runTest<peg::must<config::STRING, peg::eolf>>(content)),
                  std::exception);
   }
   {
     // This will fail due to an extra internal quote
-    const std::string content = "\"te\"st\"";
+    const std::string content = R"("te"st")";
     std::optional<RetType> ret;
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
     EXPECT_THROW(ret.emplace(runTest<peg::must<config::STRING, peg::eolf>>(content)),
                  std::exception);
   }
 }
 
+// NOLINTNEXTLINE
 TEST(config_grammar, VALUE) {
   // NOTE: Can't use the `checkResult` helper here due to the need to check multiple types.
   auto checkValue = [](const std::string& input) {
     std::optional<RetType> ret;
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
     ASSERT_NO_THROW(ret.emplace(runTest<peg::must<config::VALUE, peg::eolf>>(input)));
     ASSERT_TRUE(ret.has_value());
     ASSERT_TRUE(ret.value().first);
@@ -352,9 +376,11 @@ TEST(config_grammar, VALUE) {
   }
 }
 
+// NOLINTNEXTLINE
 TEST(config_grammar, KEY) {
   auto checkKey = [](const std::string& input) {
     std::optional<RetType> ret;
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
     ASSERT_NO_THROW(ret.emplace(runTest<peg::must<config::KEY, peg::eolf>>(input)));
     ASSERT_TRUE(ret.has_value());
     ASSERT_TRUE(ret.value().first);
@@ -365,6 +391,7 @@ TEST(config_grammar, KEY) {
 
   auto failKey = [](const std::string& input) {
     std::optional<RetType> ret;
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
     EXPECT_THROW(ret.emplace(runTest<peg::must<config::KEY, peg::eolf>>(input)), std::exception)
         << "Input key: " << input;
   };
@@ -420,6 +447,7 @@ TEST(config_grammar, KEY) {
   }
 }
 
+// NOLINTNEXTLINE
 TEST(config_grammar, VAR) {
   auto checkVar = [](const std::string& input) {
     std::optional<config::ActionData> out;
@@ -430,6 +458,7 @@ TEST(config_grammar, VAR) {
   };
   auto failVar = [](const std::string& input) {
     std::optional<RetType> ret;
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
     EXPECT_THROW(ret.emplace(runTest<peg::must<config::VAR, peg::eolf>>(input)), std::exception);
   };
 
@@ -451,6 +480,7 @@ TEST(config_grammar, VAR) {
   }
 }
 
+// NOLINTNEXTLINE
 TEST(config_grammar, FULLPAIR) {
   const std::string flat_key = "float.my.value";
   std::string content = flat_key + "   =  5.37e+6";
@@ -459,8 +489,10 @@ TEST(config_grammar, FULLPAIR) {
   EXPECT_TRUE(ret.first);
   // Eliminate any vector elements with an empty map. This may be the case due to the way that flat
   // keys are resolved into structs.
-  ret.second.cfg_res.erase(std::remove_if(ret.second.cfg_res.begin(), ret.second.cfg_res.end(),
-                                          [](const auto& m) { return m.empty(); }));
+  ret.second.cfg_res.erase(
+      std::remove_if(std::begin(ret.second.cfg_res), std::end(ret.second.cfg_res),
+                     [](const auto& m) { return m.empty(); }),
+      std::end(ret.second.cfg_res));
   ASSERT_EQ(ret.second.cfg_res.size(), 1);
   config::types::CfgMap* cfg_map = &ret.second.cfg_res.front();
   const auto keys = utils::split(flat_key, '.');
@@ -474,6 +506,7 @@ TEST(config_grammar, FULLPAIR) {
   EXPECT_EQ(cfg_map->at(keys.back())->type, config::types::Type::kNumber);
 }
 
+// NOLINTNEXTLINE
 TEST(config_grammar, FLAT_KEY) {
   std::string content = "this.is.a.var.ref";
   auto ret = runTest<peg::must<config::FLAT_KEY, peg::eolf>>(content);
@@ -482,6 +515,7 @@ TEST(config_grammar, FLAT_KEY) {
   ASSERT_EQ(ret.second.flat_keys[0], content);
 }
 
+// NOLINTNEXTLINE
 TEST(config_grammar, VAR_REF) {
   auto checkVarRef = [](const std::string& input) {
     std::optional<config::ActionData> out;
@@ -492,6 +526,7 @@ TEST(config_grammar, VAR_REF) {
   };
   auto failVarRef = [](const std::string& input) {
     std::optional<RetType> ret;
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
     EXPECT_THROW(ret.emplace(runTest<peg::must<config::VAR, peg::eolf>>(input)), std::exception);
   };
   // These are all valid vars

--- a/tests/config_helpers_test.cpp
+++ b/tests/config_helpers_test.cpp
@@ -16,6 +16,7 @@ void testIsStructLike(Args&&... args) {
 }
 }  // namespace
 
+// NOLINTNEXTLINE
 TEST(config_helpers_test, isStructLike) {
   testIsStructLike<config::types::ConfigValue>("");
 
@@ -30,6 +31,7 @@ TEST(config_helpers_test, isStructLike) {
   testIsStructLike<config::types::ConfigReference>("reference", "proto", 0);
 }
 
+// NOLINTNEXTLINE
 TEST(config_helpers_test, checkForErrors) {
   {
     // This test should fail due to duplicate keys
@@ -39,6 +41,7 @@ TEST(config_helpers_test, checkForErrors) {
     config::types::CfgMap cfg2 = {{key, std::make_shared<config::types::ConfigValue>(
                                             "string", config::types::Type::kString)}};
 
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
     EXPECT_THROW(config::helpers::checkForErrors(cfg1, cfg2, key), config::DuplicateKeyException);
   }
   {
@@ -49,6 +52,7 @@ TEST(config_helpers_test, checkForErrors) {
     config::types::CfgMap cfg2 = {
         {key, std::make_shared<config::types::ConfigStruct>(key, 0 /* depth doesn't matter */)}};
 
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
     EXPECT_THROW(config::helpers::checkForErrors(cfg1, cfg2, key), config::MismatchKeyException);
   }
   {
@@ -59,6 +63,7 @@ TEST(config_helpers_test, checkForErrors) {
     config::types::CfgMap cfg2 = {
         {key, std::make_shared<config::types::ConfigStruct>(key, 0 /* depth doesn't matter */)}};
 
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
     EXPECT_THROW(config::helpers::checkForErrors(cfg1, cfg2, key), config::MismatchTypeException);
   }
   {
@@ -69,6 +74,7 @@ TEST(config_helpers_test, checkForErrors) {
     config::types::CfgMap cfg2 = {
         {key, std::make_shared<config::types::ConfigStruct>(key, 0 /* depth doesn't matter */)}};
 
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
     EXPECT_NO_THROW(config::helpers::checkForErrors(cfg1, cfg2, key));
   }
   {
@@ -81,13 +87,16 @@ TEST(config_helpers_test, checkForErrors) {
     config::types::CfgMap cfg2 = {
         {key2, std::make_shared<config::types::ConfigStruct>(key2, 0 /* depth doesn't matter */)}};
 
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
     EXPECT_THROW(config::helpers::checkForErrors(cfg1, cfg2, key1), std::out_of_range)
         << "cfg1: " << cfg1 << ", cfg2: " << cfg2;
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
     EXPECT_THROW(config::helpers::checkForErrors(cfg1, cfg2, key2), std::out_of_range)
         << "cfg1: " << cfg1 << ", cfg2: " << cfg2;
   }
 }
 
+// NOLINTNEXTLINE
 TEST(config_helpers_test, mergeNestedMaps) {
   {
     // This test should succeed (no exceptions thrown)
@@ -126,6 +135,7 @@ TEST(config_helpers_test, mergeNestedMaps) {
     //    key3 = ""
     //    key4 = ""
     config::types::CfgMap cfg_out{};
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
     ASSERT_NO_THROW(cfg_out = config::helpers::mergeNestedMaps(cfg1, cfg2));
 
     // The resulting map contains the top level key.
@@ -168,6 +178,7 @@ TEST(config_helpers_test, mergeNestedMaps) {
     config::types::CfgMap cfg2 = {{cfg2_struct->name, std::move(cfg2_struct)}};
 
     config::types::CfgMap cfg_out{};
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
     ASSERT_THROW(cfg_out = config::helpers::mergeNestedMaps(cfg1, cfg2),
                  config::DuplicateKeyException);
   }
@@ -233,6 +244,7 @@ TEST(config_helpers_test, mergeNestedMaps) {
     //      key3 = ""
     //      key4 = ""
     config::types::CfgMap cfg_out{};
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
     ASSERT_NO_THROW(cfg_out = config::helpers::mergeNestedMaps(cfg1, cfg2));
 
     // The inner struct should contain all of the above keys and no more.
@@ -252,6 +264,7 @@ TEST(config_helpers_test, mergeNestedMaps) {
   }
 }
 
+// NOLINTNEXTLINE
 TEST(config_helpers_test, structFromReference) {
   {
     // This test should succeed (no exceptions thrown)
@@ -268,9 +281,11 @@ TEST(config_helpers_test, structFromReference) {
     //    $KEY4 = "bar"
     auto reference = std::make_shared<config::types::ConfigReference>(ref_name, proto_name,
                                                                       4 /* depth doesn't matter */);
-    reference->data = {{keys[0], std::make_shared<config::types::ConfigValue>(
-                                     "0.14", config::types::Type::kNumber, 0.14)},
-                       {keys[1], std::make_shared<config::types::ConfigValue>("fizz_buzz")}};
+    constexpr double MAGIC_NUMBER{0.14};
+    reference->data = {
+        {keys[0], std::make_shared<config::types::ConfigValue>(
+                      std::to_string(MAGIC_NUMBER), config::types::Type::kNumber, MAGIC_NUMBER)},
+        {keys[1], std::make_shared<config::types::ConfigValue>("fizz_buzz")}};
     reference->ref_vars = {{"$KEY3", std::make_shared<config::types::ConfigValue>("foo")},
                            {"$KEY4", std::make_shared<config::types::ConfigValue>("bar")}};
 
@@ -288,6 +303,7 @@ TEST(config_helpers_test, structFromReference) {
         {keys[4], std::make_shared<config::types::ConfigValue>(expected_proto_values[keys[4]])}};
 
     std::shared_ptr<config::types::ConfigStruct> struct_out{};
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
     ASSERT_NO_THROW(struct_out = config::helpers::structFromReference(reference, proto));
 
     // Ensure that the struct was created properly from the reference
@@ -338,6 +354,7 @@ TEST(config_helpers_test, structFromReference) {
   }
 }
 
+// NOLINTNEXTLINE
 TEST(config_helpers_test, replaceVarInStr) {
   {
     const std::string input = "this.is.a.$VAR";
@@ -423,6 +440,7 @@ TEST(config_helpers_test, replaceVarInStr) {
   }
 }
 
+// NOLINTNEXTLINE
 TEST(config_helpers_test, resolveVarRefs) {
   {
     const std::string expected_value = "10";
@@ -433,6 +451,7 @@ TEST(config_helpers_test, resolveVarRefs) {
         {"outer", std::make_shared<config::types::ConfigValueLookup>("inner.key1")},
         {struct_like->name, struct_like}};
 
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
     EXPECT_NO_THROW(config::helpers::resolveVarRefs(cfg, cfg));
 
     ASSERT_EQ(cfg["outer"]->type, config::types::Type::kValue);
@@ -449,6 +468,7 @@ TEST(config_helpers_test, resolveVarRefs) {
         {"bar", std::make_shared<config::types::ConfigValueLookup>("baz")},
         {"baz", std::make_shared<config::types::ConfigValueLookup>("foo")}};
 
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
     EXPECT_THROW(config::helpers::resolveVarRefs(cfg, cfg), config::CyclicReferenceException);
   }
 }

--- a/tests/config_parse_test.cpp
+++ b/tests/config_parse_test.cpp
@@ -16,14 +16,17 @@ namespace peg = TAO_PEGTL_NAMESPACE;
 
 class InputString : public testing::TestWithParam<std::string> {};
 
+// NOLINTNEXTLINE
 TEST_P(InputString, ParseTree) {
   auto parse = []() {
     peg::memory_input in(GetParam(), "From content");
     auto root = peg::parse_tree::parse<config::grammar, config::selector>(in);
   };
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
   EXPECT_NO_THROW(parse());
 }
 
+// NOLINTNEXTLINE
 TEST_P(InputString, Parse) {
   logger::setLevel(logger::Severity::INFO);
   auto parse = []() {
@@ -32,18 +35,22 @@ TEST_P(InputString, Parse) {
     return peg::parse<config::grammar, config::action>(in, out);
   };
   bool ret{false};
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
   EXPECT_NO_THROW(ret = parse());
   EXPECT_TRUE(ret);
 }
 
+// NOLINTNEXTLINE
 TEST_P(InputString, ConfigReaderParse) {
   logger::setLevel(logger::Severity::INFO);
   ConfigReader cfg;
   bool success{false};
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
   EXPECT_NO_THROW(success = cfg.parse(GetParam(), "From String"));
   EXPECT_TRUE(success);
 }
 
+// NOLINTNEXTLINE
 INSTANTIATE_TEST_SUITE_P(ConfigParse, InputString, testing::Values(std::string("\n\
 struct test1 {\n\
     key1 = \"value\"\n\
@@ -62,11 +69,15 @@ struct test2 {\n\
 class FileInput : public testing::TestWithParam<std::filesystem::path> {};
 
 namespace {
-const std::filesystem::path base_dir = std::filesystem::path(EXAMPLE_DIR);
+auto baseDir() -> const std::filesystem::path& {
+  static const std::filesystem::path base_dir = std::filesystem::path(EXAMPLE_DIR);
+  return base_dir;
+}
+
 auto filenameGenerator() -> std::vector<std::filesystem::path> {
   std::vector<std::filesystem::path> files;
   auto genFilename = [](std::size_t idx) -> std::filesystem::path {
-    return base_dir / ("config_example" + std::to_string(idx) + ".cfg");
+    return baseDir() / ("config_example" + std::to_string(idx) + ".cfg");
   };
   for (size_t idx = 1;; ++idx) {
     const auto cfg_file = genFilename(idx);
@@ -79,32 +90,39 @@ auto filenameGenerator() -> std::vector<std::filesystem::path> {
 }
 }  // namespace
 
+// NOLINTNEXTLINE
 TEST_P(FileInput, ParseTree) {
   auto parse = []() {
-    peg::file_input in(base_dir / GetParam());
+    peg::file_input in(baseDir() / GetParam());
     auto root = peg::parse_tree::parse<config::grammar, config::selector>(in);
   };
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
   EXPECT_NO_THROW(parse());
 }
 
+// NOLINTNEXTLINE
 TEST_P(FileInput, Parse) {
   logger::setLevel(logger::Severity::WARN);
   auto parse = []() {
-    peg::file_input in(base_dir / GetParam());
+    peg::file_input in(baseDir() / GetParam());
     config::ActionData out;
     return peg::parse<config::grammar, config::action>(in, out);
   };
   bool ret{false};
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
   EXPECT_NO_THROW(ret = parse());
   EXPECT_TRUE(ret);
 }
 
+// NOLINTNEXTLINE
 TEST_P(FileInput, ConfigReaderParse) {
   logger::setLevel(logger::Severity::WARN);
   ConfigReader cfg;
   bool success{false};
-  EXPECT_NO_THROW(success = cfg.parse(base_dir / GetParam()));
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
+  EXPECT_NO_THROW(success = cfg.parse(baseDir() / GetParam()));
   EXPECT_TRUE(success);
 }
 
+// NOLINTNEXTLINE
 INSTANTIATE_TEST_SUITE_P(ConfigParse, FileInput, testing::ValuesIn(filenameGenerator()));

--- a/tests/math_test.cpp
+++ b/tests/math_test.cpp
@@ -17,32 +17,37 @@
 namespace peg = TAO_PEGTL_NAMESPACE;
 
 namespace {
-const std::vector<std::pair<std::string, double>> test_strings = {
-    // Inject some whitespace to test robustness to it.
-    {" 3.14159 * 1e3", 3141.5899999999997},
-    {"0.5 *  (0.7 + 1.2 ) ", 0.95},
-    {"0.5 + 0.7 * 1.2     ", 1.3399999999999999},
-    {"3*0.27 - 2.3**0.5 - 5 * 4", -20.70657508881031},
-    {"  3 ^ 2.4 * 12.2 + 0.1 + 4.3 ", 174.79264401590646},
-    {"-4.7 * -(3.72 + -pi  ) ", 2.7185145281279732},
-    {"  1/3 * -( 5 + 4 )  ", -3.0},
-    {"\t3.4 * -(1.9**2 * (1/3.1 - 6) * (2.54- 17.0)\t)", -1007.6399690322581}};
-
 using RefMap = std::map<std::string, double>;
+}
 
-const std::vector<std::tuple<std::string, double, RefMap>> test_w_var_ref = {
-    {"0.5 * ($(test1.key) - 0.234)", 0.503, {{"test1.key", 1.24}}},
-    {"3*$(var_ref1) - 2.3**$(exponent) - 5 * 4",
-     -20.70657508881031,
-     {{"var_ref1", 0.27}, {"exponent", 0.5}}},
-    {"  $(its.a.three) ^ 2.4 * $(another.var) + $(one.more.value) + 4.3 ",
-     174.79264401590646,
-     {{"its.a.three", 3}, {"another.var", 12.2}, {"one.more.value", 0.1}}}};
-}  // namespace
+class MathExpressionTest : public ::testing::Test {
+ protected:
+  const std::vector<std::pair<std::string, double>> test_strings = {
+      // Inject some whitespace to test robustness to it.
+      {" 3.14159 * 1e3", 3141.5899999999997},
+      {"0.5 *  (0.7 + 1.2 ) ", 0.95},
+      {"0.5 + 0.7 * 1.2     ", 1.3399999999999999},
+      {"3*0.27 - 2.3**0.5 - 5 * 4", -20.70657508881031},
+      {"  3 ^ 2.4 * 12.2 + 0.1 + 4.3 ", 174.79264401590646},
+      {"-4.7 * -(3.72 + -pi  ) ", 2.7185145281279732},
+      {"  1/3 * -( 5 + 4 )  ", -3.0},
+      {"\t3.4 * -(1.9**2 * (1/3.1 - 6) * (2.54- 17.0)\t)", -1007.6399690322581}};
 
-TEST(math_expression, analyze) { ASSERT_EQ(peg::analyze<math::expression>(), 0); }
+  const std::vector<std::tuple<std::string, double, RefMap>> test_w_var_ref = {
+      {"0.5 * ($(test1.key) - 0.234)", 0.503, {{"test1.key", 1.24}}},
+      {"3*$(var_ref1) - 2.3**$(exponent) - 5 * 4",
+       -20.70657508881031,
+       {{"var_ref1", 0.27}, {"exponent", 0.5}}},
+      {"  $(its.a.three) ^ 2.4 * $(another.var) + $(one.more.value) + 4.3 ",
+       174.79264401590646,
+       {{"its.a.three", 3}, {"another.var", 12.2}, {"one.more.value", 0.1}}}};
+};
 
-TEST(math_expression, evaluate) {
+// NOLINTNEXTLINE
+TEST(MathExpressionGrammar, analyze) { ASSERT_EQ(peg::analyze<math::expression>(), 0); }
+
+// NOLINTNEXTLINE
+TEST_F(MathExpressionTest, evaluate) {
   auto test_input = [](const std::string& input) -> double {
     peg::memory_input in(input, "from content");
     math::ActionData out;
@@ -53,6 +58,7 @@ TEST(math_expression, evaluate) {
   for (const auto& input : test_strings) {
     std::cout << "Input: " << input.first << std::endl;
     double result{0};
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
     EXPECT_NO_THROW(result = test_input(input.first));
     EXPECT_FLOAT_EQ(result, input.second);
   }
@@ -60,11 +66,13 @@ TEST(math_expression, evaluate) {
   // We'll intentionally omit the var_ref_map here to ensure a failure occurs
   for (const auto& input : test_w_var_ref) {
     std::cout << "Input: " << std::get<0>(input) << std::endl;
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
     EXPECT_THROW(test_input(std::get<0>(input)), std::runtime_error);
   }
 }
 
-TEST(math_expression, evaluate_var_ref) {
+// NOLINTNEXTLINE
+TEST_F(MathExpressionTest, evaluate_var_ref) {
   auto test_input = [](const std::string& input, const RefMap& ref_map) -> double {
     peg::memory_input in(input, "from content");
     math::ActionData out;
@@ -76,17 +84,20 @@ TEST(math_expression, evaluate_var_ref) {
   for (const auto& input : test_w_var_ref) {
     std::cout << "Input: " << std::get<0>(input) << std::endl;
     double result{0};
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
     EXPECT_NO_THROW(result = test_input(std::get<0>(input), std::get<2>(input)));
     EXPECT_FLOAT_EQ(result, std::get<1>(input));
   }
 }
 
-TEST(grammar2_expression, analyze) {
+// NOLINTNEXTLINE
+TEST(MathExpressionGrammar, g2_analyze) {
   namespace math = grammar2;
   ASSERT_EQ(peg::analyze<math::expression>(), 0);
 }
 
-TEST(grammar2_expression, evaluate) {
+// NOLINTNEXTLINE
+TEST_F(MathExpressionTest, g2_evaluate) {
   namespace math = grammar2;
 
   auto test_input = [](const std::string& input) -> double {
@@ -99,6 +110,7 @@ TEST(grammar2_expression, evaluate) {
   for (const auto& input : test_strings) {
     std::cout << "Input: " << input.first << std::endl;
     double result{0};
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
     EXPECT_NO_THROW(result = test_input(input.first));
     EXPECT_FLOAT_EQ(result, input.second);
   }
@@ -106,11 +118,13 @@ TEST(grammar2_expression, evaluate) {
   // We'll intentionally omit the var_ref_map here to ensure a failure occurs
   for (const auto& input : test_w_var_ref) {
     std::cout << "Input: " << std::get<0>(input) << std::endl;
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
     EXPECT_THROW(test_input(std::get<0>(input)), std::runtime_error);
   }
 }
 
-TEST(grammar2_expression, evaluate_var_ref) {
+// NOLINTNEXTLINE
+TEST_F(MathExpressionTest, g2_evaluate_var_ref) {
   namespace math = grammar2;
 
   auto test_input = [](const std::string& input, const RefMap& ref_map) -> double {
@@ -124,6 +138,7 @@ TEST(grammar2_expression, evaluate_var_ref) {
   for (const auto& input : test_w_var_ref) {
     std::cout << "Input: " << std::get<0>(input) << std::endl;
     double result{0};
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
     EXPECT_NO_THROW(result = test_input(std::get<0>(input), std::get<2>(input)));
     EXPECT_FLOAT_EQ(result, std::get<1>(input));
   }

--- a/tests/utils_test.cpp
+++ b/tests/utils_test.cpp
@@ -14,6 +14,7 @@ void compareVecEq(const std::vector<std::string>& expected, const std::vector<st
 };
 }  // namespace
 
+// NOLINTNEXTLINE
 TEST(utils_test, trim) {
   std::string base = "This is a test";
 
@@ -32,13 +33,30 @@ TEST(utils_test, trim) {
     std::string test_str = "   \n  " + base + "   \n\t\t\t   ";
     EXPECT_EQ(utils::trim(test_str), base);
   }
+  {
+    // Leading non-whitespace
+    std::string test_str = "{{{" + base;
+    EXPECT_EQ(utils::trim(test_str, "{"), base);
+  }
+  {
+    // Trailing non-whitespace
+    std::string test_str = base + "}}}}}";
+    EXPECT_EQ(utils::trim(test_str, "}"), base);
+  }
+  {
+    // Enclosing non-whitespace
+    std::string test_str = "{{" + base + "}}}}";
+    EXPECT_EQ(utils::trim(test_str, "{}"), base);
+  }
 }
 
+// NOLINTNEXTLINE
 TEST(utils_test, split) {
   auto combine_str = [](const std::vector<std::string>& in, const std::string& sep) -> std::string {
     std::string combined = in[0];
     for (size_t i = 1; i < in.size(); ++i) {
-      combined += sep + in[i];
+      combined += sep;
+      combined += in[i];
     }
     return combined;
   };
@@ -61,6 +79,7 @@ TEST(utils_test, split) {
   }
 }
 
+// NOLINTNEXTLINE
 TEST(utils_test, join) {
   {
     const std::vector<std::string> input{"this", "is", "a", "test"};
@@ -79,13 +98,14 @@ TEST(utils_test, join) {
     EXPECT_EQ(expected, output);
   }
   {
-    const std::string expected = "";
+    const std::string expected{};
     const auto output = utils::join({}, ";");
 
     EXPECT_EQ(expected, output);
   }
 }
 
+// NOLINTNEXTLINE
 TEST(utils_test, splitAndJoin) {
   {
     const std::vector<std::string> input = {"This", "should", "always", "pass"};
@@ -112,6 +132,7 @@ TEST(utils_test, splitAndJoin) {
   }
 }
 
+// NOLINTNEXTLINE
 TEST(utils_test, makeName) {
   {
     // Single value first
@@ -132,5 +153,9 @@ TEST(utils_test, makeName) {
     const std::string expected = part1 + "." + part2;
     const auto result = utils::makeName(part1, part2);
     EXPECT_EQ(expected, result);
+  }
+  {
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
+    EXPECT_THROW(utils::makeName("", ""), std::runtime_error);
   }
 }


### PR DESCRIPTION
*  Addresses possible exception in main
*  Address clang-tidy issues in all tests
*  Adds ignore rule for macros in cognitive complexity check