### PR TITLE
Missing final key exception

### DIFF
--- a/examples/config_example5.cfg
+++ b/examples/config_example5.cfg
@@ -15,7 +15,7 @@ struct protos {
       key_3 = $LEG
 
       reference protos.joint_proto as hx  {  # Can we make the 'hx' here be represented by $DOF?
-        $DOF = "hx"
+        $DOF = $PARENT_NAME
         +extra_key = 1.e-3
       }
     }
@@ -41,7 +41,7 @@ struct outer   {
     key_between = 4
 
     reference protos.leg_proto as fl {
-      $LEG = "fl"
+      $LEG = $PARENT_NAME
       $DOF = "hx"
     }
 }

--- a/include/flexi_cfg/config/reader.h
+++ b/include/flexi_cfg/config/reader.h
@@ -90,20 +90,7 @@ void ConfigReader::getValue(const std::string& name, T& value) const {
   // Split the key into parts
   const auto keys = utils::split(name, '.');
 
-  const auto struct_like = config::helpers::getNestedConfig(cfg_data_, keys);
-
-  // Special handling for the case where 'name' contains a single key (i.e. is not a flat key):
-  const auto& cfg_map = (struct_like != nullptr) ? struct_like->data : cfg_data_;
-
-  // If this is a nested key, we need to make sure the final key exists in the result struct_like
-  // object:
-  if (!cfg_map.contains(keys.back())) {
-    const auto head_tail = utils::splitTail(name);
-    THROW_EXCEPTION(config::InvalidKeyException, "Key '{}' not contained in '{}'!",
-                    head_tail.second, head_tail.first);
-  }
-  // Special handling for the case where 'name' contains a single key (i.e is not a flat key)
-  const auto cfg_val = cfg_map.at(keys.back());
+  const auto cfg_val = config::helpers::getConfigValue(cfg_data_, keys);
 
   const auto value_ptr = dynamic_pointer_cast<config::types::ConfigValue>(cfg_val);
   const auto value_str = value_ptr->value;
@@ -116,11 +103,7 @@ void ConfigReader::getValue(const std::string& name, std::vector<T>& value) cons
   // Split the key into parts
   const auto keys = utils::split(name, '.');
 
-  const auto struct_like = config::helpers::getNestedConfig(cfg_data_, keys);
-
-  // Special handling for the case where 'name' contains a single key (i.e is not a flat key)
-  const auto cfg_val =
-      (struct_like != nullptr) ? struct_like->data.at(keys.back()) : cfg_data_.at(keys.back());
+  const auto cfg_val = config::helpers::getConfigValue(cfg_data_, keys);
 
   // Ensure this is a list if the user is asking for a list.
   if (cfg_val->type != config::types::Type::kList) {
@@ -143,11 +126,7 @@ void ConfigReader::getValue(const std::string& name, std::array<T, N>& value) co
   // Split the key into parts
   const auto keys = utils::split(name, '.');
 
-  const auto struct_like = config::helpers::getNestedConfig(cfg_data_, keys);
-
-  // Special handling for the case where 'name' contains a single key (i.e is not a flat key)
-  const auto cfg_val =
-      (struct_like != nullptr) ? struct_like->data.at(keys.back()) : cfg_data_.at(keys.back());
+  const auto cfg_val = config::helpers::getConfigValue(cfg_data_, keys);
 
   // Ensure this is a list if the user is asking for a list.
   if (cfg_val->type != config::types::Type::kList) {

--- a/include/flexi_cfg/config/reader.h
+++ b/include/flexi_cfg/config/reader.h
@@ -92,6 +92,14 @@ void ConfigReader::getValue(const std::string& name, T& value) const {
 
   const auto struct_like = config::helpers::getNestedConfig(cfg_data_, keys);
 
+  // If this is a nested key, we need to make sure the final key exists in the result struct_like
+  // object:
+  if (struct_like != nullptr && !struct_like->data.contains(keys.back())) {
+    const auto head_tail = utils::splitTail(name);
+    THROW_EXCEPTION(
+        config::InvalidKeyException,
+        "Subtree '{}' does not contain key '{}'!", head_tail.first, head_tail.second);
+  }
   // Special handling for the case where 'name' contains a single key (i.e is not a flat key)
   const auto cfg_val =
       (struct_like != nullptr) ? struct_like->data.at(keys.back()) : cfg_data_.at(keys.back());
@@ -115,8 +123,8 @@ void ConfigReader::getValue(const std::string& name, std::vector<T>& value) cons
 
   // Ensure this is a list if the user is asking for a list.
   if (cfg_val->type != config::types::Type::kList) {
-    throw config::InvalidTypeException(
-        fmt::format("Expected '{}' to contain a list, but is of type {}", name, cfg_val->type));
+    THROW_EXCEPTION(config::InvalidTypeException,
+        "Expected '{}' to contain a list, but is of type {}", name, cfg_val->type);
   }
 
   const auto& list = dynamic_pointer_cast<config::types::ConfigList>(cfg_val)->data;
@@ -142,14 +150,14 @@ void ConfigReader::getValue(const std::string& name, std::array<T, N>& value) co
 
   // Ensure this is a list if the user is asking for a list.
   if (cfg_val->type != config::types::Type::kList) {
-    throw config::InvalidTypeException(
-        fmt::format("Expected '{}' to contain a list, but is of type {}", name, cfg_val->type));
+    THROW_EXCEPTION(config::InvalidTypeException,
+        "Expected '{}' to contain a list, but is of type {}", name, cfg_val->type);
   }
 
   const auto& list = dynamic_pointer_cast<config::types::ConfigList>(cfg_val)->data;
   if (list.size() != N) {
-    throw std::runtime_error(
-        fmt::format("Expected {} entries in '{}', but found {}!", N, cfg_val, list.size()));
+    THROW_EXCEPTION(std::runtime_error,
+        "Expected {} entries in '{}', but found {}!", N, cfg_val, list.size());
   }
   for (size_t i = 0; i < N; ++i) {
     const auto value_ptr = dynamic_pointer_cast<config::types::ConfigValue>(list[i]);

--- a/src/config_helpers.cpp
+++ b/src/config_helpers.cpp
@@ -292,19 +292,19 @@ auto getConfigValue(const types::CfgMap& cfg, const std::vector<std::string>& ke
     -> types::BasePtr {
   // Get the struct-like object containing the last key of the ConfigValueLookup:
   const auto struct_like = getNestedConfig(cfg, keys);
-  // Extract the value from the struct-like object by accessing the internal data and locating the
-  // requested key.
-  if (struct_like != nullptr) {
-    if (!struct_like->data.contains(keys.back())) {
-      auto keys_minus_tail = keys;
-      keys_minus_tail.pop_back();
-      THROW_EXCEPTION(InvalidKeyException, "Unable to find '{}' in '{}'!", keys.back(),
-                      utils::join(keys_minus_tail, "."));
-    }
-    return struct_like->data.at(keys.back());
+
+  // Special handling for the case where 'keys' only has one entry:
+  const auto& cfg_tail = (struct_like != nullptr) ? struct_like->data : cfg;
+
+  if (!cfg_tail.contains(keys.back())) {
+    auto keys_minus_tail = keys;
+    keys_minus_tail.pop_back();
+    THROW_EXCEPTION(InvalidKeyException, "Unable to find '{}' in '{}'!", keys.back(),
+                    utils::join(keys_minus_tail, "."));
   }
 
-  return cfg.at(keys.back());
+  // Extract the value from the final CfgMap object using the final key.
+  return cfg_tail.at(keys.back());
 }
 
 auto getConfigValue(const types::CfgMap& cfg, const std::shared_ptr<types::ConfigValueLookup>& var)

--- a/src/config_helpers.cpp
+++ b/src/config_helpers.cpp
@@ -266,10 +266,10 @@ auto getNestedConfig(const types::CfgMap& cfg, const std::vector<std::string>& k
     }
 
     rejoined = utils::makeName(rejoined, key);
-    // This may be uneccessary error checking (if this is a part of a flat key, then it must be
-    // a nested structure), but we check here that this object is a `StructLike` object,
-    // otherwise we can't access the `data` member.
+
     struct_like = dynamic_pointer_cast<types::ConfigStructLike>(content->at(key));
+    // If the dynamic_pointer_cast fails, then we can't continue with the loop and whatever is
+    // returned by 'content->at(key)' doesn't have any content of it's own.
     if (struct_like == nullptr) {
       THROW_EXCEPTION(InvalidTypeException,
                       "Expected value at '{}' to be a struct-like object, but got {} type instead.",

--- a/src/config_reader.cpp
+++ b/src/config_reader.cpp
@@ -156,8 +156,8 @@ auto ConfigReader::getNestedConfig(const std::string& key) const
 
 void ConfigReader::convert(const std::string& value_str, config::types::Type type, float& value) {
   if (type != config::types::Type::kNumber) {
-    THROW_EXCEPTION(config::MismatchTypeException,
-		    "Expected numeric type, but have '{}' type.", type);
+    THROW_EXCEPTION(config::MismatchTypeException, "Expected numeric type, but have '{}' type.",
+                    type);
   }
   std::size_t len{0};
   value = std::stof(value_str, &len);
@@ -170,8 +170,8 @@ void ConfigReader::convert(const std::string& value_str, config::types::Type typ
 
 void ConfigReader::convert(const std::string& value_str, config::types::Type type, double& value) {
   if (type != config::types::Type::kNumber) {
-    THROW_EXCEPTION(config::MismatchTypeException,
-		    "Expected numeric type, but have '{}' type.", type);
+    THROW_EXCEPTION(config::MismatchTypeException, "Expected numeric type, but have '{}' type.",
+                    type);
   }
   std::size_t len{0};
   value = std::stod(value_str, &len);
@@ -184,8 +184,8 @@ void ConfigReader::convert(const std::string& value_str, config::types::Type typ
 
 void ConfigReader::convert(const std::string& value_str, config::types::Type type, int& value) {
   if (type != config::types::Type::kNumber) {
-    THROW_EXCEPTION(config::MismatchTypeException,
-		    "Expected numeric type, but have '{}' type.", type);
+    THROW_EXCEPTION(config::MismatchTypeException, "Expected numeric type, but have '{}' type.",
+                    type);
   }
   std::size_t len{0};
   value = std::stoi(value_str, &len);
@@ -198,8 +198,8 @@ void ConfigReader::convert(const std::string& value_str, config::types::Type typ
 
 void ConfigReader::convert(const std::string& value_str, config::types::Type type, int64_t& value) {
   if (type != config::types::Type::kNumber) {
-    THROW_EXCEPTION(config::MismatchTypeException,
-		    "Expected numeric type, but have '{}' type.", type);
+    THROW_EXCEPTION(config::MismatchTypeException, "Expected numeric type, but have '{}' type.",
+                    type);
   }
   std::size_t len{0};
   value = std::stoll(value_str, &len);
@@ -212,16 +212,17 @@ void ConfigReader::convert(const std::string& value_str, config::types::Type typ
 
 void ConfigReader::convert(const std::string& value_str, config::types::Type type, bool& value) {
   if (type != config::types::Type::kBoolean) {
-    THROW_EXCEPTION(config::MismatchTypeException,
-		    "Expected boolean type, but have '{}' type.", type);
+    THROW_EXCEPTION(config::MismatchTypeException, "Expected boolean type, but have '{}' type.",
+                    type);
   }
   value = value_str == "true";
 }
 
-void ConfigReader::convert(const std::string& value_str, config::types::Type type, std::string& value) {
+void ConfigReader::convert(const std::string& value_str, config::types::Type type,
+                           std::string& value) {
   if (type != config::types::Type::kString) {
-    THROW_EXCEPTION(config::MismatchTypeException,
-		    "Expected string type, but have '{}' type.", type);
+    THROW_EXCEPTION(config::MismatchTypeException, "Expected string type, but have '{}' type.",
+                    type);
   }
   value = value_str;
   value.erase(std::remove(std::begin(value), std::end(value), '\"'), std::end(value));

--- a/tests/config_grammar_test.cpp
+++ b/tests/config_grammar_test.cpp
@@ -288,7 +288,7 @@ TEST(config_grammar, BOOLEAN) {
   auto checkBoolean = [](const std::string& input, bool expected) {
     std::optional<config::ActionData> out;
     checkResult<peg::must<config::BOOLEAN, peg::eolf>, config::types::ConfigValue>(
-	input, config::types::Type::kBoolean, out);
+        input, config::types::Type::kBoolean, out);
     const auto value = dynamic_pointer_cast<config::types::ConfigValue>(out->obj_res);
     ASSERT_NE(value, nullptr);
     ASSERT_NO_THROW(std::any_cast<bool>(value->value_any));


### PR DESCRIPTION
Instead of throwing the `map::at` exception, throw the `InvalidKeyException` with some additional information to help trace the failure.