### PR TITLE
Enable default constructor for Reader

### DIFF
--- a/include/flexi_cfg/reader.h
+++ b/include/flexi_cfg/reader.h
@@ -22,6 +22,7 @@ namespace flexi_cfg {
 class Reader {
  public:
   explicit Reader(config::types::CfgMap cfg, std::string parent = "");
+  Reader() = default;
   ~Reader() = default;
 
   Reader(const Reader&) = default;
@@ -54,8 +55,6 @@ class Reader {
       -> std::pair<std::string, const config::types::CfgMap&>;
 
  private:
-  Reader() = default;
-
   static void convert(const std::string& value_str, config::types::Type type, float& value);
   static void convert(const std::string& value_str, config::types::Type type, double& value);
   static void convert(const std::string& value_str, config::types::Type type, int& value);


### PR DESCRIPTION
Since Reader no longer has all the parsing logic tied to it, it is now just a container that stores some data. Semantically, a data container should have an empty base state. This will help with the ergonomics of using the Reader as well.