### PR TITLE
Adds support for nested std::vector<T> objects

### DIFF
--- a/examples/config_example5.cfg
+++ b/examples/config_example5.cfg
@@ -56,4 +56,6 @@ struct outer   {
       $LEG = $PARENT_NAME
       $DOF = "hx"
     }
+
+    multi_list = [[1, 2, 3], [4, 5, 6], [7, 8, 9, 10]]
 }

--- a/include/flexi_cfg/config/classes.h
+++ b/include/flexi_cfg/config/classes.h
@@ -171,9 +171,9 @@ class ConfigValue : public ConfigBaseClonable<ConfigBase, ConfigValue> {
   ConfigValue(ConfigValue&&) = default;
 };
 
-class ConfigList : public ConfigBaseClonable<ConfigBase, ConfigList> {
+class ConfigList : public ConfigBaseClonable<ConfigValue, ConfigList> {
  public:
-  ConfigList() : ConfigBaseClonable(Type::kList){};
+  ConfigList(std::string value_in = "") : ConfigBaseClonable(std::move(value_in), Type::kList){};
 
   void stream(std::ostream& os) const override {
     os << "[";

--- a/include/flexi_cfg/config/classes.h
+++ b/include/flexi_cfg/config/classes.h
@@ -27,6 +27,9 @@ using RefMap = std::map<std::string, BasePtr>;
 class ConfigProto;
 using ProtoMap = std::map<std::string, std::shared_ptr<ConfigProto>>;
 
+class ConfigValue;
+using ValuePtr = std::shared_ptr<ConfigValue>;
+
 enum class Type {
   kValue,
   kString,

--- a/include/flexi_cfg/reader.h
+++ b/include/flexi_cfg/reader.h
@@ -55,12 +55,12 @@ class Reader {
       -> std::pair<std::string, const config::types::CfgMap&>;
 
  private:
-  static void convert(const std::shared_ptr<config::types::ConfigValue>& value_ptr, float& value);
-  static void convert(const std::shared_ptr<config::types::ConfigValue>& value_ptr, double& value);
-  static void convert(const std::shared_ptr<config::types::ConfigValue>& value_ptr, int& value);
-  static void convert(const std::shared_ptr<config::types::ConfigValue>& value_ptr, int64_t& value);
-  static void convert(const std::shared_ptr<config::types::ConfigValue>& value_ptr, bool& value);
-  static void convert(const std::shared_ptr<config::types::ConfigValue>& value_ptr, std::string& value);
+  static void convert(const config::types::ValuePtr& value_ptr, float& value);
+  static void convert(const config::types::ValuePtr& value_ptr, double& value);
+  static void convert(const config::types::ValuePtr& value_ptr, int& value);
+  static void convert(const config::types::ValuePtr& value_ptr, int64_t& value);
+  static void convert(const config::types::ValuePtr& value_ptr, bool& value);
+  static void convert(const config::types::ValuePtr& value_ptr, std::string& value);
 
   // template <typename T>
   // static void convert(const std::shared_ptr<config::types::ConfigValue>& value_ptr, std::vector<T>& value); 

--- a/include/flexi_cfg/reader.h
+++ b/include/flexi_cfg/reader.h
@@ -123,16 +123,10 @@ void Reader::getValue(const std::string& name, std::vector<T>& value) const {
                     "Expected '{}' to contain a list, but is of type {}",
                     utils::makeName(parent_name_, name), cfg_val->type);
   }
-
   logger::debug("Reading vector of type: {}", typeid(T).name());
 
-  const auto& list = dynamic_pointer_cast<config::types::ConfigList>(cfg_val)->data;
-  for (const auto& e : list) {
-    const auto value_ptr = dynamic_pointer_cast<config::types::ConfigValue>(e);
-    T v{};
-    convert(value_ptr, v);
-    value.emplace_back(v);
-  }
+  const auto& value_ptr = dynamic_pointer_cast<config::types::ConfigValue>(cfg_val);
+  convert(value_ptr, value);
 }
 
 template <typename T, size_t N>

--- a/include/flexi_cfg/reader.h
+++ b/include/flexi_cfg/reader.h
@@ -55,15 +55,15 @@ class Reader {
       -> std::pair<std::string, const config::types::CfgMap&>;
 
  private:
-  static void convert(const std::string& value_str, config::types::Type type, float& value);
-  static void convert(const std::string& value_str, config::types::Type type, double& value);
-  static void convert(const std::string& value_str, config::types::Type type, int& value);
-  static void convert(const std::string& value_str, config::types::Type type, int64_t& value);
-  static void convert(const std::string& value_str, config::types::Type type, bool& value);
-  static void convert(const std::string& value_str, config::types::Type type, std::string& value);
+  static void convert(const std::shared_ptr<config::types::ConfigValue>& value_ptr, float& value);
+  static void convert(const std::shared_ptr<config::types::ConfigValue>& value_ptr, double& value);
+  static void convert(const std::shared_ptr<config::types::ConfigValue>& value_ptr, int& value);
+  static void convert(const std::shared_ptr<config::types::ConfigValue>& value_ptr, int64_t& value);
+  static void convert(const std::shared_ptr<config::types::ConfigValue>& value_ptr, bool& value);
+  static void convert(const std::shared_ptr<config::types::ConfigValue>& value_ptr, std::string& value);
 
-  template <typename T>
-  static void convert(const std::string& value_str, config::types::Type type, std::vector<T>& value); 
+  // template <typename T>
+  // static void convert(const std::shared_ptr<config::types::ConfigValue>& value_ptr, std::vector<T>& value); 
 
   void getValue(const std::string& name, Reader& reader) const;
 
@@ -88,10 +88,14 @@ void Reader::getValue(const std::string& name, T& value) const {
   const auto cfg_val = config::helpers::getConfigValue(cfg_data_, keys);
 
   const auto value_ptr = dynamic_pointer_cast<config::types::ConfigValue>(cfg_val);
-  const auto value_str = value_ptr->value;
-  convert(value_str, value_ptr->type, value);
+  convert(value_ptr, value);
   logger::debug(" -- Type is {}", typeid(T).name());
 }
+
+// template <typename T>
+// void convert(const std::string& value_str, config::types::Type type, std::vector<T>& value) {
+//   logger::debug("value_str: {}, type: {}", value_str, type);
+// }
 
 template <typename T>
 void Reader::getValue(const std::string& name, std::vector<T>& value) const {
@@ -110,9 +114,8 @@ void Reader::getValue(const std::string& name, std::vector<T>& value) const {
   const auto& list = dynamic_pointer_cast<config::types::ConfigList>(cfg_val)->data;
   for (const auto& e : list) {
     const auto value_ptr = dynamic_pointer_cast<config::types::ConfigValue>(e);
-    const auto value_str = value_ptr->value;
     T v{};
-    convert(value_str, value_ptr->type, v);
+    convert(value_ptr, v);
     value.emplace_back(v);
   }
 }
@@ -139,8 +142,7 @@ void Reader::getValue(const std::string& name, std::array<T, N>& value) const {
   }
   for (size_t i = 0; i < N; ++i) {
     const auto value_ptr = dynamic_pointer_cast<config::types::ConfigValue>(list[i]);
-    const auto value_str = value_ptr->value;
-    convert(value_str, value_ptr->type, value[i]);
+    convert(value_ptr, value[i]);
   }
 }
 

--- a/include/flexi_cfg/reader.h
+++ b/include/flexi_cfg/reader.h
@@ -62,8 +62,8 @@ class Reader {
   static void convert(const config::types::ValuePtr& value_ptr, bool& value);
   static void convert(const config::types::ValuePtr& value_ptr, std::string& value);
 
-  // template <typename T>
-  // static void convert(const std::shared_ptr<config::types::ConfigValue>& value_ptr, std::vector<T>& value); 
+  template <typename T>
+  static void convert(const config::types::ValuePtr& value_ptr, std::vector<T>& value);
 
   void getValue(const std::string& name, Reader& reader) const;
 
@@ -92,10 +92,11 @@ void Reader::getValue(const std::string& name, T& value) const {
   logger::debug(" -- Type is {}", typeid(T).name());
 }
 
-// template <typename T>
-// void convert(const std::string& value_str, config::types::Type type, std::vector<T>& value) {
-//   logger::debug("value_str: {}, type: {}", value_str, type);
-// }
+template <typename T>
+void convert(const std::shared_ptr<config::types::ConfigValue>& value_ptr, std::vector<T>& value) {
+  logger::debug("value_ptr: {}", value_ptr);
+  logger::debug("value: {}, type: {}", value_ptr->value, value_ptr->type);
+}
 
 template <typename T>
 void Reader::getValue(const std::string& name, std::vector<T>& value) const {

--- a/include/flexi_cfg/reader.h
+++ b/include/flexi_cfg/reader.h
@@ -62,6 +62,9 @@ class Reader {
   static void convert(const std::string& value_str, config::types::Type type, bool& value);
   static void convert(const std::string& value_str, config::types::Type type, std::string& value);
 
+  template <typename T>
+  static void convert(const std::string& value_str, config::types::Type type, std::vector<T>& value); 
+
   void getValue(const std::string& name, Reader& reader) const;
 
   // All of the config data!

--- a/src/config_reader.cpp
+++ b/src/config_reader.cpp
@@ -78,76 +78,76 @@ auto Reader::getNestedConfig(const std::string& key) const
   return {keys.back(), data};
 }
 
-void Reader::convert(const std::string& value_str, config::types::Type type, float& value) {
-  if (type != config::types::Type::kNumber) {
+void Reader::convert(const std::shared_ptr<config::types::ConfigValue>& value_ptr, float& value) {
+  if (value_ptr->type != config::types::Type::kNumber) {
     THROW_EXCEPTION(config::MismatchTypeException, "Expected numeric type, but have '{}' type.",
-                    type);
+                    value_ptr->type);
   }
   std::size_t len{0};
-  value = std::stof(value_str, &len);
-  if (len != value_str.size()) {
+  value = std::stof(value_ptr->value, &len);
+  if (len != value_ptr->value.size()) {
     THROW_EXCEPTION(config::MismatchTypeException,
                     "Error while converting '{}' to type float. Processed {} of {} characters",
-                    value_str, len, value_str.size());
+                    value_ptr->value, len, value_ptr->value.size());
   }
 }
 
-void Reader::convert(const std::string& value_str, config::types::Type type, double& value) {
-  if (type != config::types::Type::kNumber) {
+void Reader::convert(const std::shared_ptr<config::types::ConfigValue>& value_ptr, double& value) {
+  if (value_ptr->type != config::types::Type::kNumber) {
     THROW_EXCEPTION(config::MismatchTypeException, "Expected numeric type, but have '{}' type.",
-                    type);
+                    value_ptr->type);
   }
   std::size_t len{0};
-  value = std::stod(value_str, &len);
-  if (len != value_str.size()) {
+  value = std::stod(value_ptr->value, &len);
+  if (len != value_ptr->value.size()) {
     THROW_EXCEPTION(config::MismatchTypeException,
                     "Error while converting '{}' to type double. Processed {} of {} characters",
-                    value_str, len, value_str.size());
+                    value_ptr->value, len, value_ptr->value.size());
   }
 }
 
-void Reader::convert(const std::string& value_str, config::types::Type type, int& value) {
-  if (type != config::types::Type::kNumber) {
+void Reader::convert(const std::shared_ptr<config::types::ConfigValue>& value_ptr, int& value) {
+  if (value_ptr->type != config::types::Type::kNumber) {
     THROW_EXCEPTION(config::MismatchTypeException, "Expected numeric type, but have '{}' type.",
-                    type);
+                    value_ptr->type);
   }
   std::size_t len{0};
-  value = std::stoi(value_str, &len);
-  if (len != value_str.size()) {
+  value = std::stoi(value_ptr->value, &len);
+  if (len != value_ptr->value.size()) {
     THROW_EXCEPTION(config::MismatchTypeException,
                     "Error while converting '{}' to type int. Processed {} of {} characters",
-                    value_str, len, value_str.size());
+                    value_ptr->value, len, value_ptr->value.size());
   }
 }
 
-void Reader::convert(const std::string& value_str, config::types::Type type, int64_t& value) {
-  if (type != config::types::Type::kNumber) {
+void Reader::convert(const std::shared_ptr<config::types::ConfigValue>& value_ptr, int64_t& value) {
+  if (value_ptr->type != config::types::Type::kNumber) {
     THROW_EXCEPTION(config::MismatchTypeException, "Expected numeric type, but have '{}' type.",
-                    type);
+                    value_ptr->type);
   }
   std::size_t len{0};
-  value = std::stoll(value_str, &len);
-  if (len != value_str.size()) {
+  value = std::stoll(value_ptr->value, &len);
+  if (len != value_ptr->value.size()) {
     THROW_EXCEPTION(config::MismatchTypeException,
                     "Error while converting '{}' to type int64_t. Processed {} of {} characters",
-                    value_str, len, value_str.size());
+                    value_ptr->value, len, value_ptr->value.size());
   }
 }
 
-void Reader::convert(const std::string& value_str, config::types::Type type, bool& value) {
-  if (type != config::types::Type::kBoolean) {
+void Reader::convert(const std::shared_ptr<config::types::ConfigValue>& value_ptr, bool& value) {
+  if (value_ptr->type != config::types::Type::kBoolean) {
     THROW_EXCEPTION(config::MismatchTypeException, "Expected boolean type, but have '{}' type.",
-                    type);
+                    value_ptr->type);
   }
-  value = value_str == "true";
+  value = value_ptr->value == "true";
 }
 
-void Reader::convert(const std::string& value_str, config::types::Type type, std::string& value) {
-  if (type != config::types::Type::kString) {
+void Reader::convert(const std::shared_ptr<config::types::ConfigValue>& value_ptr, std::string& value) {
+  if (value_ptr->type != config::types::Type::kString) {
     THROW_EXCEPTION(config::MismatchTypeException, "Expected string type, but have '{}' type.",
-                    type);
+                    value_ptr->type);
   }
-  value = value_str;
+  value = value_ptr->value;
   value.erase(std::remove(std::begin(value), std::end(value), '\"'), std::end(value));
 }
 

--- a/src/config_reader.cpp
+++ b/src/config_reader.cpp
@@ -78,7 +78,7 @@ auto Reader::getNestedConfig(const std::string& key) const
   return {keys.back(), data};
 }
 
-void Reader::convert(const std::shared_ptr<config::types::ConfigValue>& value_ptr, float& value) {
+void Reader::convert(const config::types::ValuePtr& value_ptr, float& value) {
   if (value_ptr->type != config::types::Type::kNumber) {
     THROW_EXCEPTION(config::MismatchTypeException, "Expected numeric type, but have '{}' type.",
                     value_ptr->type);
@@ -92,7 +92,7 @@ void Reader::convert(const std::shared_ptr<config::types::ConfigValue>& value_pt
   }
 }
 
-void Reader::convert(const std::shared_ptr<config::types::ConfigValue>& value_ptr, double& value) {
+void Reader::convert(const config::types::ValuePtr& value_ptr, double& value) {
   if (value_ptr->type != config::types::Type::kNumber) {
     THROW_EXCEPTION(config::MismatchTypeException, "Expected numeric type, but have '{}' type.",
                     value_ptr->type);
@@ -106,7 +106,7 @@ void Reader::convert(const std::shared_ptr<config::types::ConfigValue>& value_pt
   }
 }
 
-void Reader::convert(const std::shared_ptr<config::types::ConfigValue>& value_ptr, int& value) {
+void Reader::convert(const config::types::ValuePtr& value_ptr, int& value) {
   if (value_ptr->type != config::types::Type::kNumber) {
     THROW_EXCEPTION(config::MismatchTypeException, "Expected numeric type, but have '{}' type.",
                     value_ptr->type);
@@ -120,7 +120,7 @@ void Reader::convert(const std::shared_ptr<config::types::ConfigValue>& value_pt
   }
 }
 
-void Reader::convert(const std::shared_ptr<config::types::ConfigValue>& value_ptr, int64_t& value) {
+void Reader::convert(const config::types::ValuePtr& value_ptr, int64_t& value) {
   if (value_ptr->type != config::types::Type::kNumber) {
     THROW_EXCEPTION(config::MismatchTypeException, "Expected numeric type, but have '{}' type.",
                     value_ptr->type);
@@ -134,7 +134,7 @@ void Reader::convert(const std::shared_ptr<config::types::ConfigValue>& value_pt
   }
 }
 
-void Reader::convert(const std::shared_ptr<config::types::ConfigValue>& value_ptr, bool& value) {
+void Reader::convert(const config::types::ValuePtr& value_ptr, bool& value) {
   if (value_ptr->type != config::types::Type::kBoolean) {
     THROW_EXCEPTION(config::MismatchTypeException, "Expected boolean type, but have '{}' type.",
                     value_ptr->type);
@@ -142,7 +142,7 @@ void Reader::convert(const std::shared_ptr<config::types::ConfigValue>& value_pt
   value = value_ptr->value == "true";
 }
 
-void Reader::convert(const std::shared_ptr<config::types::ConfigValue>& value_ptr, std::string& value) {
+void Reader::convert(const config::types::ValuePtr& value_ptr, std::string& value) {
   if (value_ptr->type != config::types::Type::kString) {
     THROW_EXCEPTION(config::MismatchTypeException, "Expected string type, but have '{}' type.",
                     value_ptr->type);

--- a/src/config_reader_example.cpp
+++ b/src/config_reader_example.cpp
@@ -88,14 +88,12 @@ auto main(int argc, char* argv[]) -> int {
       const auto out_f = cfg.getValue<float>(int_key);
       fmt::print("Value of '{}' is: {}\n", int_key, out_f);
     }
-    /*
     {
       // Read a list of lists
       const auto my_nested_list_key = "outer.multi_list";
       const auto out = cfg.getValue<std::vector<std::vector<int>>>(my_nested_list_key);
-      fmt::print("Value of '{}' is : [{}]", my_nested_list_key, fmt::join(out, ", "));
+      fmt::print("Value of '{}' is : [{}]\n", my_nested_list_key, fmt::join(out, ", "));
     }
-    */
     {
       // We can get a sub-struct:
       const std::string struct_key = "this.is";

--- a/src/config_reader_example.cpp
+++ b/src/config_reader_example.cpp
@@ -89,6 +89,12 @@ auto main(int argc, char* argv[]) -> int {
       fmt::print("Value of '{}' is: {}\n", int_key, out_f);
     }
     {
+      // Read a list of lists
+      const auto my_nested_list_key = "outer.multi_list";
+      const auto out = cfg.getValue<std::vector<std::vector<int>>>(my_nested_list_key);
+      fmt::print("Value of '{}' is : [{}]", my_nested_list_key, fmt::join(out, ", "));
+    }
+    {
       // We can get a sub-struct:
       const std::string struct_key = "this.is";
       const auto out = cfg.getValue<flexi_cfg::Reader>(struct_key);

--- a/src/config_reader_example.cpp
+++ b/src/config_reader_example.cpp
@@ -88,12 +88,14 @@ auto main(int argc, char* argv[]) -> int {
       const auto out_f = cfg.getValue<float>(int_key);
       fmt::print("Value of '{}' is: {}\n", int_key, out_f);
     }
+    /*
     {
       // Read a list of lists
       const auto my_nested_list_key = "outer.multi_list";
       const auto out = cfg.getValue<std::vector<std::vector<int>>>(my_nested_list_key);
       fmt::print("Value of '{}' is : [{}]", my_nested_list_key, fmt::join(out, ", "));
     }
+    */
     {
       // We can get a sub-struct:
       const std::string struct_key = "this.is";


### PR DESCRIPTION
*  Adds examples for reading objects of type `std::vector<std::vector<T>>` from a config file.