### PR TITLE
Improves usage of `$PARENT_NAME` keyword

### DIFF
--- a/include/flexi_cfg/config/classes.h
+++ b/include/flexi_cfg/config/classes.h
@@ -365,9 +365,11 @@ class ConfigProto : public ConfigBaseClonable<ConfigStructLike, ConfigProto> {
 
 class ConfigReference : public ConfigBaseClonable<ConfigStructLike, ConfigReference> {
  public:
-  ConfigReference(std::string name, std::string proto_name, std::size_t depth)
-      : ConfigBaseClonable(Type::kReference, std::move(name), depth),
-        proto{std::move(proto_name)} {};
+  ConfigReference(const std::string& name, std::string proto_name, std::size_t depth)
+      : ConfigBaseClonable(Type::kReference, name, depth), proto{std::move(proto_name)} {
+    // Create the required key to easily reference the parent name.
+    ref_vars["$PARENT_NAME"] = std::make_shared<ConfigValue>(name, Type::kString);
+  }
 
   void stream(std::ostream& os) const override {
     const auto ws = std::string(depth * tw, ' ');

--- a/include/flexi_cfg/config/exceptions.h
+++ b/include/flexi_cfg/config/exceptions.h
@@ -6,7 +6,7 @@
 
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define THROW_EXCEPTION(E_TYPE, MSG_F, ...) \
-  throw E_TYPE(fmt::format("At {}:{} \n" MSG_F, __FILE__, __LINE__, ##__VA_ARGS__));
+  throw E_TYPE(fmt::format("{} at {}:{}\n" MSG_F, #E_TYPE, __FILE__, __LINE__, ##__VA_ARGS__));
 
 namespace flexi_cfg::config {
 

--- a/include/flexi_cfg/logger.h
+++ b/include/flexi_cfg/logger.h
@@ -114,6 +114,17 @@ static void critical(std::string_view msg) { Logger::instance().log(Severity::CR
 
 }  // namespace flexi_cfg::logger
 
+#define LOG(SEVERITY, MSG_F, ...)  \
+  flexi_cfg::logger::log(SEVERITY, \
+                         fmt::format("{}:{} - " MSG_F, __FILE__, __LINE__, ##__VA_ARGS__));
+
+#define LOG_T(MSG_F, ...) LOG(flexi_cfg::logger::Severity::TRACE, MSG_F, ##__VA_ARGS__)
+#define LOG_D(MSG_F, ...) LOG(flexi_cfg::logger::Severity::DEBUG, MSG_F, ##__VA_ARGS__)
+#define LOG_I(MSG_F, ...) LOG(flexi_cfg::logger::Severity::INFO, MSG_F, ##__VA_ARGS__)
+#define LOG_W(MSG_F, ...) LOG(flexi_cfg::logger::Severity::WARN, MSG_F, ##__VA_ARGS__)
+#define LOG_E(MSG_F, ...) LOG(flexi_cfg::logger::Severity::ERROR, MSG_F, ##__VA_ARGS__)
+#define LOG_C(MSG_F, ...) LOG(flexi_cfg::logger::Severity::CRITICAL, MSG_F, ##__VA_ARGS__)
+
 template <>
 struct fmt::formatter<flexi_cfg::logger::Severity> : formatter<std::string_view> {
   // parse is inherited from formatter<string_view>

--- a/include/flexi_cfg/reader.h
+++ b/include/flexi_cfg/reader.h
@@ -112,16 +112,16 @@ void Reader::getValue(const std::string& key, T& value) const {
   // Split the key into parts
   const auto keys = utils::split(key, '.');
 
-  const auto cfg_val = config::helpers::getConfigValue(cfg_data_, keys);
-
   try {
+    const auto cfg_val = config::helpers::getConfigValue(cfg_data_, keys);
+
     const auto value_ptr = dynamic_pointer_cast<config::types::ConfigValue>(cfg_val);
     convert(value_ptr, value);
     logger::debug(" -- Type is {}", typeid(T).name());
   } catch (const std::runtime_error& e) {
     // Catch and re-throw with extra information to aid in debugging.
-    THROW_EXCEPTION(std::runtime_error, "While reading '{}': {}",
-                    utils::makeName(parent_name_, key), e.what());
+    LOG_E("While reading '{}':", utils::makeName(parent_name_, key));
+    throw;
   }
 }
 
@@ -176,23 +176,23 @@ void Reader::getValue(const std::string& key, std::vector<T>& value) const {
   // Split the key into parts
   const auto keys = utils::split(key, '.');
 
-  const auto cfg_val = config::helpers::getConfigValue(cfg_data_, keys);
-
-  // Ensure this is a list if the user is asking for a list.
-  if (cfg_val->type != config::types::Type::kList) {
-    THROW_EXCEPTION(config::InvalidTypeException,
-                    "Expected '{}' to contain a list, but is of type {}",
-                    utils::makeName(parent_name_, key), cfg_val->type);
-  }
-  logger::debug("Reading vector of type: {}", typeid(T).name());
-
   try {
+    const auto cfg_val = config::helpers::getConfigValue(cfg_data_, keys);
+
+    // Ensure this is a list if the user is asking for a list.
+    if (cfg_val->type != config::types::Type::kList) {
+      THROW_EXCEPTION(config::InvalidTypeException,
+                      "Expected '{}' to contain a list, but is of type {}",
+                      utils::makeName(parent_name_, key), cfg_val->type);
+    }
+    logger::debug("Reading vector of type: {}", typeid(T).name());
+
     const auto& value_ptr = dynamic_pointer_cast<config::types::ConfigValue>(cfg_val);
     convert(value_ptr, value);
   } catch (const std::runtime_error& e) {
     // Catch and re-throw with extra information to aid in debugging.
-    THROW_EXCEPTION(std::runtime_error, "While reading '{}': {}",
-                    utils::makeName(parent_name_, key), e.what());
+    LOG_E("While reading '{}':", utils::makeName(parent_name_, key));
+    throw;
   }
 }
 
@@ -201,23 +201,22 @@ void Reader::getValue(const std::string& key, std::array<T, N>& value) const {
   // Split the key into parts
   const auto keys = utils::split(key, '.');
 
-  const auto cfg_val = config::helpers::getConfigValue(cfg_data_, keys);
-
-  // Ensure this is a list if the user is asking for a list.
-  if (cfg_val->type != config::types::Type::kList) {
-    THROW_EXCEPTION(config::InvalidTypeException,
-                    "Expected '{}' to contain a list, but is of type {}",
-                    utils::makeName(parent_name_, key), cfg_val->type);
-  }
-  logger::debug("Reading array of type: {}", typeid(T).name());
-
   try {
+    const auto cfg_val = config::helpers::getConfigValue(cfg_data_, keys);
+
+    // Ensure this is a list if the user is asking for a list.
+    if (cfg_val->type != config::types::Type::kList) {
+      THROW_EXCEPTION(config::InvalidTypeException,
+                      "Expected '{}' to contain a list, but is of type {}",
+                      utils::makeName(parent_name_, key), cfg_val->type);
+    }
+    logger::debug("Reading array of type: {}", typeid(T).name());
+
     const auto& value_ptr = dynamic_pointer_cast<config::types::ConfigValue>(cfg_val);
     convert(value_ptr, value);
   } catch (const std::runtime_error& e) {
-    // Catch and re-throw with extra information to aid in debugging.
-    THROW_EXCEPTION(std::runtime_error, "While reading '{}': {}",
-                    utils::makeName(parent_name_, key), e.what());
+    LOG_E("While reading '{}':", utils::makeName(parent_name_, key));
+    throw;
   }
 }
 

--- a/src/config_reader.cpp
+++ b/src/config_reader.cpp
@@ -119,12 +119,19 @@ auto Reader::getNestedConfig(const std::string& key) const
   // Split the key into parts
   const auto keys = utils::split(key, '.');
 
-  const auto struct_like = config::helpers::getNestedConfig(cfg_data_, keys);
+  try {
+    const auto struct_like = config::helpers::getNestedConfig(cfg_data_, keys);
 
-  // Special handling for the case where 'key' contains a single key (i.e is not a flat key)
-  const auto& data = (struct_like != nullptr) ? struct_like->data : cfg_data_;
+    // Special handling for the case where 'key' contains a single key (i.e is not a flat key)
+    const auto& data = (struct_like != nullptr) ? struct_like->data : cfg_data_;
 
-  return {keys.back(), data};
+    return {keys.back(), data};
+  } catch (const std::exception& e) {
+    LOG_E("Error while getting key '{}':", key);
+    throw;
+  }
+
+  return {keys.back(), {}};
 }
 
 void Reader::convert(const config::types::ValuePtr& value_ptr, float& value) {


### PR DESCRIPTION
*  Fixes an issue that prevented `$PARENT_NAME` from being used within a string just like proto-vars can be used.
*  Improves error messages when config entry is not found
*  Adds some log helper macros