### PR TITLE
Properly register exceptions in pybind 11

### DIFF
--- a/examples/config_example1.cfg
+++ b/examples/config_example1.cfg
@@ -16,3 +16,9 @@ struct test2 {
 }
 
 solo_key  =     10.1
+
+int_list = [0, 1, 3, -5]
+uint_list = [0x0, 0x1, 0x3, 0x5]
+float_list = [0.0, 1.0, 3.0, -5.0]
+uint64 = -5
+

--- a/python/flexi_cfg_py.cpp
+++ b/python/flexi_cfg_py.cpp
@@ -155,6 +155,29 @@ PYBIND11_MODULE(flexi_cfg, m) {
       .value("kUnknown", flexi_cfg::config::types::Type::kUnknown)
       .export_values();
 
+  auto pyFlexiCfgException =
+      py::register_exception<flexi_cfg::config::Exception>(m, "Exception", PyExc_RuntimeError);
+  py::register_exception<flexi_cfg::config::InvalidTypeException>(m, "InvalidTypeException",
+                                                                  pyFlexiCfgException);
+  py::register_exception<flexi_cfg::config::InvalidStateException>(m, "InvalidStateException",
+                                                                   pyFlexiCfgException);
+  py::register_exception<flexi_cfg::config::InvalidConfigException>(m, "InvalidConfigException",
+                                                                    pyFlexiCfgException);
+  py::register_exception<flexi_cfg::config::InvalidKeyException>(m, "InvalidKeyException",
+                                                                 pyFlexiCfgException);
+  py::register_exception<flexi_cfg::config::DuplicateKeyException>(m, "DuplicateKeyException",
+                                                                   pyFlexiCfgException);
+  py::register_exception<flexi_cfg::config::MismatchKeyException>(m, "MismatchKeyException",
+                                                                  pyFlexiCfgException);
+  py::register_exception<flexi_cfg::config::MismatchTypeException>(m, "MismatchTypeException",
+                                                                   pyFlexiCfgException);
+  py::register_exception<flexi_cfg::config::UndefinedReferenceVarException>(
+      m, "UndefinedReferenceVarException", pyFlexiCfgException);
+  py::register_exception<flexi_cfg::config::UndefinedProtoException>(m, "UndefinedProtoException",
+                                                                     pyFlexiCfgException);
+  py::register_exception<flexi_cfg::config::CyclicReferenceException>(m, "CyclicReferenceException",
+                                                                      pyFlexiCfgException);
+
   py::class_<flexi_cfg::Reader>(m, "Reader")
       .def("dump", &flexi_cfg::Reader::dump)
       .def("exists", &flexi_cfg::Reader::exists)
@@ -177,6 +200,13 @@ PYBIND11_MODULE(flexi_cfg, m) {
       .def("getReader", &getValueHelper<flexi_cfg::Reader>)
       // Generic accessor
       .def("getValue", &getValueGeneric);
+
+  py::class_<flexi_cfg::Parser>(m, "Parser")
+      .def_static("parse",
+                  py::overload_cast<const std::filesystem::path&>(&flexi_cfg::Parser::parse))
+      .def_static("parse",
+                  py::overload_cast<std::string_view, std::string_view>(&flexi_cfg::Parser::parse),
+                  py::arg("cfg_string"), py::pos_only(), py::arg("source") = "unknown");
 
   m.def("parse", py::overload_cast<const std::filesystem::path&>(&flexi_cfg::parse));
   m.def("parse", py::overload_cast<std::string_view, std::string_view>(&flexi_cfg::parse),

--- a/python/test_flexi_cfg.py
+++ b/python/test_flexi_cfg.py
@@ -78,7 +78,11 @@ class TestMyConfig(unittest.TestCase):
                         'test2': {'my_key': 'foo',
                                   'n_key': 0x1234,
                                   'var_ref': None},
-                        'solo_key': 10.1}
+                        'solo_key': 10.1,
+                        'int_list': [0, 1, 3, -5],
+                        'uint_list': [0x0, 0x1, 0x3, 0x5],
+                        'float_list': [0.0, 1.0, 3.0, -5.0],
+                        'uint64': -5}
         expected_cfg['test2']['var_ref'] = expected_cfg['test1']['key3']
         
         cfg = flexi_cfg.parse(cfg_file_path)
@@ -89,7 +93,35 @@ class TestMyConfig(unittest.TestCase):
 
         self.assertEqual(cfg.getType('test1.f'), flexi_cfg.Type.kList)
         self.assertEqual(cfg.getStringList('test1.f'), expected_cfg['test1']['f'])
-        
+
+        # Check that parsing a signed integer as an unsigned integer produces an exception.
+        excepted = False
+        try:
+            cfg.getUint64('uint64')
+        except flexi_cfg.MismatchTypeException:
+            excepted = True
+        except:
+            self.assertTrue(False)
+        self.assertTrue(excepted)
+
+        # Check various list types:
+        self.assertEqual(cfg.getIntList('int_list'), expected_cfg['int_list'])
+        self.assertEqual(cfg.getUint64List('uint_list'), expected_cfg['uint_list'])
+        self.assertEqual(cfg.getFloatList('float_list'), expected_cfg['float_list'])
+
+        # Check the generic getValue() method:
+        self.assertEqual(cfg.getValue('test1.key1'), expected_cfg['test1']['key1'])
+        self.assertEqual(cfg.getValue('test1.key2'), expected_cfg['test1']['key2'])
+        self.assertAlmostEqual(cfg.getValue('test1.key3'), expected_cfg['test1']['key3'], places=6)
+        self.assertEqual(cfg.getValue('test2.my_key'), expected_cfg['test2']['my_key'])
+        self.assertEqual(cfg.getValue('test2.n_key'), expected_cfg['test2']['n_key'])
+        self.assertAlmostEqual(cfg.getValue('test2.var_ref'), expected_cfg['test2']['var_ref'], places=6)
+        self.assertEqual(cfg.getValue('solo_key'), expected_cfg['solo_key'])
+        self.assertEqual(cfg.getValue('int_list'), expected_cfg['int_list'])
+        self.assertEqual(cfg.getValue('uint_list'), expected_cfg['uint_list'])
+        self.assertEqual(cfg.getValue('float_list'), expected_cfg['float_list'])
+        self.assertEqual(cfg.getValue('uint64'), expected_cfg['uint64'])
+
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/src/config_reader.cpp
+++ b/src/config_reader.cpp
@@ -155,8 +155,14 @@ void Reader::convert(const config::types::ValuePtr& value_ptr, int64_t& value) {
 }
 
 void Reader::convert(const config::types::ValuePtr& value_ptr, uint64_t& value) {
-  numericConversionHelper<uint64_t>(
-      value_ptr, value, [](const auto& str, auto* l) { return std::stoull(str, l, 0); });
+  auto strict_stoull = [](const auto& str, auto* l) {
+    if (str[0] == '-') {
+      THROW_EXCEPTION(config::MismatchTypeException,
+                      "Expected unsigned type, but found negative number: {}", str);
+    }
+    return std::stoull(str, l, 0);
+  };
+  numericConversionHelper<uint64_t>(value_ptr, value, strict_stoull);
 }
 
 void Reader::convert(const config::types::ValuePtr& value_ptr, bool& value) {


### PR DESCRIPTION
* Fix accessing of unsigned `int`s. Calling `getValue<uint64_t>` on a negative int led to integer underflow . Now parsing a negative int as an unsigned results in an exception.