### PR TITLE
Issue #109: Consistent key ordering

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,14 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(range-v3)
 
+# tsl::ordered_map
+FetchContent_Declare(
+  tsl-ordered-map
+  GIT_REPOSITORY "https://github.com/Tessil/ordered-map.git"
+  GIT_TAG v1.1.0
+)
+FetchContent_MakeAvailable(tsl-ordered-map)
+
 option(ENABLE_CLANG_TIDY "Enable static analysis with clang-tidy" ON)
 if(ENABLE_CLANG_TIDY)
   if(NOT CMAKE_CROSSCOMPILING) # adds invalid paths
@@ -96,6 +104,7 @@ set(CFG_HEADERS
   include/flexi_cfg/config/grammar.h
   include/flexi_cfg/config/helpers.h
   include/flexi_cfg/config/selector.h
+  include/details/ordered_map.h
   include/flexi_cfg/logger.h
   include/flexi_cfg/math/actions.h
   include/flexi_cfg/math/grammar.h
@@ -120,6 +129,7 @@ target_link_libraries(flexi_cfg
   taocpp::pegtl
   fmt::fmt
   range-v3::range-v3
+  tsl::ordered_map
 )
 add_clang_format(flexi_cfg)
 

--- a/include/flexi_cfg/config/actions.h
+++ b/include/flexi_cfg/config/actions.h
@@ -7,7 +7,7 @@
 #include <exception>
 #include <filesystem>
 #include <iostream>
-#include <map>
+#include <unordered_map>
 #include <memory>
 #include <range/v3/view/map.hpp>
 #include <span>
@@ -53,7 +53,7 @@ struct ActionData {
 #if 0
   // I'd prefer something like this that provides a bit more type safety, but this map can't be
   // implicitly convert to a CfgMap object.
-  std::map<std::string, std::shared_ptr<types::ConfigValueLookup>>
+  std::unordered_map<std::string, std::shared_ptr<types::ConfigValueLookup>>
       value_lookups;  // This is purely for keeping track of any value lookup objects that might be
                       // contained within an expression object.
 #else

--- a/include/flexi_cfg/config/classes.h
+++ b/include/flexi_cfg/config/classes.h
@@ -2,6 +2,7 @@
 
 #include <fmt/format.h>
 #include <fmt/ostream.h>
+#include <tsl/ordered_map.h>
 
 #include <any>
 #include <iostream>
@@ -22,8 +23,8 @@ constexpr std::size_t tw{4};  // The width of the indentation
 class ConfigBase;
 using BasePtr = std::shared_ptr<ConfigBase>;
 
-using CfgMap = std::unordered_map<std::string, BasePtr>;
-using RefMap = std::unordered_map<std::string, BasePtr>;
+using CfgMap = tsl::ordered_map<std::string, BasePtr>;
+using RefMap = tsl::ordered_map<std::string, BasePtr>;
 class ConfigProto;
 using ProtoMap = std::unordered_map<std::string, std::shared_ptr<ConfigProto>>;
 
@@ -119,6 +120,22 @@ inline auto operator<<(std::ostream& os, const std::unordered_map<Key, Value>& d
   return os;
 }
 
+template <typename Key, typename Value>
+inline auto operator<<(std::ostream& os, const tsl::ordered_map<Key, Value>& data) -> std::ostream& {
+  for (const auto& kv : data) {
+    if (dynamic_pointer_cast<ConfigStructLike>(kv.second)) {
+      os << kv.second << "\n";
+    } else {
+      os << kv.first << " = " << kv.second
+#if PRINT_SRC
+         << "  # " << kv.second->loc()
+#endif
+         << "\n";
+    }
+  }
+  return os;
+}
+
 // See here for a potentially better solution:
 //    https://raw.githubusercontent.com/louisdx/cxx-prettyprint/master/prettyprint.hpp
 template <typename Key, typename Value>
@@ -138,6 +155,25 @@ inline void pprint(std::ostream& os, const std::unordered_map<Key, std::shared_p
     }
   }
 }
+
+template <typename Key, typename Value>
+inline void pprint(std::ostream& os, const tsl::ordered_map<Key, std::shared_ptr<Value>>& data,
+                   std::size_t depth) {
+  const auto ws = std::string(depth * tw, ' ');
+  for (const auto& kv : data) {
+    if (dynamic_pointer_cast<ConfigStructLike>(kv.second)) {
+      // Don't add extra whitespace, as this is handled entirely by the StructLike objects
+      os << kv.second << "\n";
+    } else {
+      os << ws << kv.first << " = " << kv.second
+#if PRINT_SRC
+         << "  # " << kv.second->loc()
+#endif
+         << "\n";
+    }
+  }
+}
+
 
 template <typename Key, typename Value>
 inline void pprint(std::ostream& os, const std::unordered_map<Key, Value>& data, std::size_t depth) {

--- a/include/flexi_cfg/config/classes.h
+++ b/include/flexi_cfg/config/classes.h
@@ -6,7 +6,7 @@
 #include <any>
 #include <iostream>
 #include <magic_enum.hpp>
-#include <map>
+#include <unordered_map>
 #include <memory>
 #include <sstream>
 #include <string>
@@ -22,10 +22,10 @@ constexpr std::size_t tw{4};  // The width of the indentation
 class ConfigBase;
 using BasePtr = std::shared_ptr<ConfigBase>;
 
-using CfgMap = std::map<std::string, BasePtr>;
-using RefMap = std::map<std::string, BasePtr>;
+using CfgMap = std::unordered_map<std::string, BasePtr>;
+using RefMap = std::unordered_map<std::string, BasePtr>;
 class ConfigProto;
-using ProtoMap = std::map<std::string, std::shared_ptr<ConfigProto>>;
+using ProtoMap = std::unordered_map<std::string, std::shared_ptr<ConfigProto>>;
 
 class ConfigValue;
 using ValuePtr = std::shared_ptr<ConfigValue>;
@@ -104,7 +104,7 @@ inline auto operator<<(std::ostream& os, const std::shared_ptr<T>& cfg) -> std::
 
 class ConfigStructLike;
 template <typename Key, typename Value>
-inline auto operator<<(std::ostream& os, const std::map<Key, Value>& data) -> std::ostream& {
+inline auto operator<<(std::ostream& os, const std::unordered_map<Key, Value>& data) -> std::ostream& {
   for (const auto& kv : data) {
     if (dynamic_pointer_cast<ConfigStructLike>(kv.second)) {
       os << kv.second << "\n";
@@ -122,7 +122,7 @@ inline auto operator<<(std::ostream& os, const std::map<Key, Value>& data) -> st
 // See here for a potentially better solution:
 //    https://raw.githubusercontent.com/louisdx/cxx-prettyprint/master/prettyprint.hpp
 template <typename Key, typename Value>
-inline void pprint(std::ostream& os, const std::map<Key, std::shared_ptr<Value>>& data,
+inline void pprint(std::ostream& os, const std::unordered_map<Key, std::shared_ptr<Value>>& data,
                    std::size_t depth) {
   const auto ws = std::string(depth * tw, ' ');
   for (const auto& kv : data) {
@@ -140,7 +140,7 @@ inline void pprint(std::ostream& os, const std::map<Key, std::shared_ptr<Value>>
 }
 
 template <typename Key, typename Value>
-inline void pprint(std::ostream& os, const std::map<Key, Value>& data, std::size_t depth) {
+inline void pprint(std::ostream& os, const std::unordered_map<Key, Value>& data, std::size_t depth) {
   const auto ws = std::string(depth * tw, ' ');
   for (const auto& kv : data) {
     os << ws << kv.first << " = " << kv.second

--- a/include/flexi_cfg/details/ordered_map.h
+++ b/include/flexi_cfg/details/ordered_map.h
@@ -2,6 +2,7 @@
 
 #include <cassert>
 #include <deque>
+#include <stdexcept>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -82,12 +83,9 @@ class ordered_map {
   // Custom iterator for the ordered_map object.
   // This iterator should iterate over the keys in the order they were inserted
   template <typename MapType, typename OrderedKeysType>
-  class iterator_base {
+  class iterator_base : public std::iterator<std::forward_iterator_tag, 
+                                             typename MapType::value_type> {
    public:
-    using iterator_category = std::forward_iterator_tag;
-    using difference_type = std::ptrdiff_t;
-    using value_type = typename Map::value_type;
-
     iterator_base(MapType& map, OrderedKeysType& keys, size_type index)
         : map_(map), keys_(keys), index_(index) {
       // Check that the offset is within bounds
@@ -139,7 +137,7 @@ class ordered_map {
 
     reference operator*() const { return *this->map_.find(this->keys_[this->index_]); }
 
-    pointer operator->() const { return this->map_[this->keys_[this->index_]]; }
+    pointer operator->() const { return &(*this->map_.find(this->keys_[this->index_])); }
 
    protected:
     friend class const_iterator_;
@@ -159,7 +157,7 @@ class ordered_map {
 
     const_reference operator*() const { return *this->map_.find(this->keys_[this->index_]); }
 
-    const_pointer operator->() const { return this->map_[this->keys_[this->index_]]; }
+    const_pointer operator->() const { return &(*this->map_.find(this->keys_[this->index_])); }
   };
 
   // Iterators

--- a/include/flexi_cfg/details/ordered_map.h
+++ b/include/flexi_cfg/details/ordered_map.h
@@ -73,8 +73,137 @@ class ordered_map {
     return *this;
   }
 
+  allocator_type get_allocator() const noexcept {
+    return map_.get_allocator();
+  }
+
+  [[nodiscard]] bool empty() const noexcept { return map_.empty; }
+
+  [[nodiscard]] size_type size() const noexcept { return map_.size(); }
+
+  [[nodiscard]] size_type max_size() const noexcept { return min(map_.max_size(), keys_.max_size()); }
+
+  // Iterators
+  // TODO: Create a custom iterator type that iterates over the keys in the order they were inserted
+  //iterator begin() noexcept {}
+  //const_iterator begin() const noexcept {}
+  //const_iterator cbegin() const noexcept {}
+  //iterator end() noexcept {}
+  //const_iterator end() const noexcept {}
+  //const_iterator cend() const noexcept {}
+
+  // TODO: Implement emplace, emplace_hint (if necessary, nothing currently uses it)
+
+  // Custom iterator for the ordered_map object.
+  // This iterator should iterate over the keys in the order they were inserted
+  class iterator_ {
+    public:
+      using iterator_category = std::forward_iterator_tag;
+      using difference_type = std::ptrdiff_t;
+      using value_type = Map::value_type;
+      using pointer = value_type*;
+      using reference = value_type&;
+
+    iterator_(Map& map, OrderedKeys& keys, size_type index) : map_(map), keys_(keys), index_(index) {
+        // Check that the offset is within bounds
+        if (index_ >= keys_.size()) {
+            throw std::out_of_range("Index out of range");
+        }
+    }
+
+    
+    reference operator*() const {
+        return *map_.find(keys_[index_]);
+    }
+
+    pointer operator->() const {
+        return map_[keys_[index_]];
+    }
+
+    // Prefix increment
+    iterator_& operator++() {
+        ++index_;
+        return *this;
+    }
+
+    // Postfix increment
+    iterator_ operator++(int) {
+        auto tmp = *this;
+        ++index_;
+        return tmp;
+    }
+
+    bool operator==(const iterator_& other) const {
+        return index_ == other.index_;
+    }
+    bool operator!=(const iterator_& other) const {
+        return index_ != other.index_;
+    }
+    private:
+    Map& map_;
+    OrderedKeys& keys_;
+    size_type index_;
+
+  };
+
+  // Custom iterator for the ordered_map object.
+  // This iterator should iterate over the keys in the order they were inserted
+  class const_iterator_ {
+    public:
+      using iterator_category = std::forward_iterator_tag;
+      using difference_type = std::ptrdiff_t;
+      using value_type = Map::value_type;
+      using const_pointer = const value_type*;
+      using const_reference = const value_type&;
+
+    const_iterator_(const Map& map, const OrderedKeys& keys, size_type index) : map_(map), keys_(keys), index_(index) {
+        // Check that the offset is within bounds
+        if (index_ >= keys_.size()) {
+            throw std::out_of_range("Index out of range");
+        }
+    }
+
+    
+    const_reference operator*() const {
+        return *map_.find(keys_[index_]);
+    }
+
+    const_pointer operator->() const {
+        return map_[keys_[index_]];
+    }
+
+    // Prefix increment
+    const_iterator_& operator++() {
+        ++index_;
+        return *this;
+    }
+
+    // Postfix increment
+    const_iterator_ operator++(int) {
+        auto tmp = *this;
+        ++index_;
+        return tmp;
+    }
+
+    bool operator==(const const_iterator_& other) const {
+        return index_ == other.index_;
+    }
+    bool operator!=(const const_iterator_& other) const {
+        return index_ != other.index_;
+    }
+    private:
+    const Map& map_;
+    const OrderedKeys& keys_;
+    size_type index_;
+
+  };
+
+
+
   const OrderedKeys& keys() const { return keys_; }
   const Map& map() const { return map_; }
+
+
 
  protected:
 };

--- a/include/flexi_cfg/details/ordered_map.h
+++ b/include/flexi_cfg/details/ordered_map.h
@@ -14,8 +14,6 @@ class ordered_map {
   using Map = std::unordered_map<Key, T, Hash, Pred, Alloc>;
   using OrderedKeys = std::vector<Key>;
 
-  // std::deque<std::pair<const Key, T>>;
-
   Map map_;
   OrderedKeys keys_;
 
@@ -33,10 +31,6 @@ class ordered_map {
   // using const_reference = ;
   // using pointer = ;
   // using const_pointer = ;
-  // using iterator = ;
-  // using const_iterator = ;
-  // using reverse_iterator = ;
-  // using const_reverse_iterator = ;
 
   ordered_map() = default;
 
@@ -47,7 +41,7 @@ class ordered_map {
 
   // Copy constructor
   ordered_map(const ordered_map&) = default;
-  
+
   // Move constructor
   ordered_map(ordered_map&&) = default;
 
@@ -61,149 +55,112 @@ class ordered_map {
 
   ordered_map(std::initializer_list<value_type> l) : map_(l) {
     std::transform(std::begin(l), std::end(l), std::back_inserter(keys_),
-    [](const value_type& value) { return value.first; });
+                   [](const value_type& value) { return value.first; });
   }
 
   // List assignment operator
-  ordered_map& operator=(std::initializer_list<value_type> l)
-  {
+  ordered_map& operator=(std::initializer_list<value_type> l) {
     map_ = l;
     std::transform(std::begin(l), std::end(l), std::back_inserter(keys_),
-    [](const value_type& value) { return value.first; });
+                   [](const value_type& value) { return value.first; });
     return *this;
   }
 
-  allocator_type get_allocator() const noexcept {
-    return map_.get_allocator();
-  }
+  allocator_type get_allocator() const noexcept { return map_.get_allocator(); }
 
   [[nodiscard]] bool empty() const noexcept { return map_.empty; }
 
   [[nodiscard]] size_type size() const noexcept { return map_.size(); }
 
-  [[nodiscard]] size_type max_size() const noexcept { return min(map_.max_size(), keys_.max_size()); }
-
-  // Iterators
-  // TODO: Create a custom iterator type that iterates over the keys in the order they were inserted
-  //iterator begin() noexcept {}
-  //const_iterator begin() const noexcept {}
-  //const_iterator cbegin() const noexcept {}
-  //iterator end() noexcept {}
-  //const_iterator end() const noexcept {}
-  //const_iterator cend() const noexcept {}
+  [[nodiscard]] size_type max_size() const noexcept {
+    return min(map_.max_size(), keys_.max_size());
+  }
 
   // TODO: Implement emplace, emplace_hint (if necessary, nothing currently uses it)
 
   // Custom iterator for the ordered_map object.
   // This iterator should iterate over the keys in the order they were inserted
-  class iterator_ {
-    public:
-      using iterator_category = std::forward_iterator_tag;
-      using difference_type = std::ptrdiff_t;
-      using value_type = Map::value_type;
-      using pointer = value_type*;
-      using reference = value_type&;
+  template <typename MapType, typename OrderedKeysType>
+  class iterator_base {
+   public:
+    using iterator_category = std::forward_iterator_tag;
+    using difference_type = std::ptrdiff_t;
+    using value_type = Map::value_type;
 
-    iterator_(Map& map, OrderedKeys& keys, size_type index) : map_(map), keys_(keys), index_(index) {
-        // Check that the offset is within bounds
-        if (index_ >= keys_.size()) {
-            throw std::out_of_range("Index out of range");
-        }
-    }
-
-    
-    reference operator*() const {
-        return *map_.find(keys_[index_]);
-    }
-
-    pointer operator->() const {
-        return map_[keys_[index_]];
+    iterator_base(MapType& map, OrderedKeysType& keys, size_type index)
+        : map_(map), keys_(keys), index_(index) {
+      // Check that the offset is within bounds
+      if (index_ > keys_.size()) {
+        throw std::out_of_range("Index out of range");
+      }
     }
 
     // Prefix increment
-    iterator_& operator++() {
-        ++index_;
-        return *this;
+    iterator_base& operator++() {
+      ++index_;
+      return *this;
     }
 
     // Postfix increment
-    iterator_ operator++(int) {
-        auto tmp = *this;
-        ++index_;
-        return tmp;
+    iterator_base operator++(int) {
+      auto tmp = *this;
+      ++index_;
+      return tmp;
     }
 
-    bool operator==(const iterator_& other) const {
-        return index_ == other.index_;
-    }
-    bool operator!=(const iterator_& other) const {
-        return index_ != other.index_;
-    }
-    private:
-    Map& map_;
-    OrderedKeys& keys_;
+    bool operator==(const iterator_base& other) const { return index_ == other.index_; }
+    bool operator!=(const iterator_base& other) const { return index_ != other.index_; }
+
+   protected:
+    MapType& map_;
+    OrderedKeysType& keys_;
     size_type index_;
+  };
 
+  class iterator_ : public iterator_base<Map, OrderedKeys> {
+   public:
+    using pointer = value_type*;
+    using reference = value_type&;
+
+    iterator_(Map& map, OrderedKeys& keys, size_type index)
+        : iterator_base<Map, OrderedKeys>(map, keys, index) {}
+
+    reference operator*() const { return *this->map_.find(this->keys_[this->index_]); }
+
+    pointer operator->() const { return this->map_[this->keys_[this->index_]]; }
   };
 
   // Custom iterator for the ordered_map object.
   // This iterator should iterate over the keys in the order they were inserted
-  class const_iterator_ {
-    public:
-      using iterator_category = std::forward_iterator_tag;
-      using difference_type = std::ptrdiff_t;
-      using value_type = Map::value_type;
-      using const_pointer = const value_type*;
-      using const_reference = const value_type&;
+  class const_iterator_ : public iterator_base<const Map, const OrderedKeys> {
+   public:
+    using const_pointer = const value_type*;
+    using const_reference = const value_type&;
 
-    const_iterator_(const Map& map, const OrderedKeys& keys, size_type index) : map_(map), keys_(keys), index_(index) {
-        // Check that the offset is within bounds
-        if (index_ >= keys_.size()) {
-            throw std::out_of_range("Index out of range");
-        }
-    }
+    const_iterator_(const Map& map, const OrderedKeys& keys, size_type index)
+        : iterator_base<const Map, const OrderedKeys>(map, keys, index) {}
 
-    
-    const_reference operator*() const {
-        return *map_.find(keys_[index_]);
-    }
+    const_reference operator*() const { return *this->map_.find(this->keys_[this->index_]); }
 
-    const_pointer operator->() const {
-        return map_[keys_[index_]];
-    }
-
-    // Prefix increment
-    const_iterator_& operator++() {
-        ++index_;
-        return *this;
-    }
-
-    // Postfix increment
-    const_iterator_ operator++(int) {
-        auto tmp = *this;
-        ++index_;
-        return tmp;
-    }
-
-    bool operator==(const const_iterator_& other) const {
-        return index_ == other.index_;
-    }
-    bool operator!=(const const_iterator_& other) const {
-        return index_ != other.index_;
-    }
-    private:
-    const Map& map_;
-    const OrderedKeys& keys_;
-    size_type index_;
-
+    const_pointer operator->() const { return this->map_[this->keys_[this->index_]]; }
   };
 
+  // Iterators
+  using iterator = iterator_;
+  using const_iterator = const_iterator_;
+  // using reverse_iterator = ;
+  // using const_reverse_iterator = ;
 
+  iterator begin() noexcept { return {map_, keys_, 0}; }
+  const_iterator begin() const noexcept { return {map_, keys_, 0}; }
+  const_iterator cbegin() const noexcept { return begin(); }
+
+  iterator end() noexcept { return {map_, keys_, keys_.size()}; }
+  const_iterator end() const noexcept { return {map_, keys_, keys_.size()}; }
+  const_iterator cend() const noexcept { return end(); }
 
   const OrderedKeys& keys() const { return keys_; }
   const Map& map() const { return map_; }
-
-
 
  protected:
 };

--- a/include/flexi_cfg/details/ordered_map.h
+++ b/include/flexi_cfg/details/ordered_map.h
@@ -1,0 +1,82 @@
+#pragma once
+
+#include <deque>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace flexi_cfg::details {
+
+template <typename Key, typename T, typename Hash = std::hash<Key>,
+          typename Pred = std::equal_to<Key>,
+          typename Alloc = std::allocator<std::pair<const Key, T>>>
+class ordered_map {
+  using Map = std::unordered_map<Key, T, Hash, Pred, Alloc>;
+  using OrderedKeys = std::vector<Key>;
+
+  // std::deque<std::pair<const Key, T>>;
+
+  Map map_;
+  OrderedKeys keys_;
+
+ public:
+  using key_type = Map::key_type;
+  using value_type = Map::value_type;
+  using mapped_type = Map::mapped_type;
+  using hasher = Map::hasher;
+  using key_equal = Map::key_equal;
+  using allocator_type = Map::allocator_type;
+
+  // Iterator related typedefs
+  using size_type = Map::size_type;
+  // using reference = ;
+  // using const_reference = ;
+  // using pointer = ;
+  // using const_pointer = ;
+  // using iterator = ;
+  // using const_iterator = ;
+  // using reverse_iterator = ;
+  // using const_reverse_iterator = ;
+
+  ordered_map() = default;
+
+  explicit ordered_map(size_type n) : map_(n), keys_(n){};
+
+  template <typename InputIterator>
+  ordered_map(InputIterator first, InputIterator last, size_type n = 0) : map_(first, last, n) {}
+
+  // Copy constructor
+  ordered_map(const ordered_map&) = default;
+  
+  // Move constructor
+  ordered_map(ordered_map&&) = default;
+
+  /// TODO: Add other constructors as necessary
+
+  // Copy assignment operator
+  ordered_map& operator=(const ordered_map&) = default;
+
+  // Move assignment operator
+  ordered_map& operator=(ordered_map&&) = default;
+
+  ordered_map(std::initializer_list<value_type> l) : map_(l) {
+    std::transform(std::begin(l), std::end(l), std::back_inserter(keys_),
+    [](const value_type& value) { return value.first; });
+  }
+
+  // List assignment operator
+  ordered_map& operator=(std::initializer_list<value_type> l)
+  {
+    map_ = l;
+    std::transform(std::begin(l), std::end(l), std::back_inserter(keys_),
+    [](const value_type& value) { return value.first; });
+    return *this;
+  }
+
+  const OrderedKeys& keys() const { return keys_; }
+  const Map& map() const { return map_; }
+
+ protected:
+};
+
+}  // namespace flexi_cfg::details

--- a/include/flexi_cfg/details/ordered_map.h
+++ b/include/flexi_cfg/details/ordered_map.h
@@ -29,17 +29,13 @@ class ordered_map {
 
   // Iterator related typedefs
   using size_type = typename Map::size_type;
-  // using reference = ;
-  // using const_reference = ;
-  // using pointer = ;
-  // using const_pointer = ;
 
   ordered_map() = default;
 
-  explicit ordered_map(size_type n) : map_(n), keys_(n){};
+  // explicit ordered_map(size_type n) : map_(n), keys_(n){};
 
   template <typename InputIterator>
-  ordered_map(InputIterator first, InputIterator last, size_type n = 0) : map_(first, last, n) {}
+  ordered_map(InputIterator first, InputIterator last) : map_(first, last) {}
 
   // Copy constructor
   ordered_map(const ordered_map&) = default;
@@ -70,7 +66,7 @@ class ordered_map {
 
   allocator_type get_allocator() const noexcept { return map_.get_allocator(); }
 
-  [[nodiscard]] bool empty() const noexcept { return map_.empty; }
+  [[nodiscard]] bool empty() const noexcept { return map_.empty(); }
 
   [[nodiscard]] size_type size() const noexcept { return map_.size(); }
 

--- a/include/flexi_cfg/details/ordered_map.h
+++ b/include/flexi_cfg/details/ordered_map.h
@@ -83,8 +83,8 @@ class ordered_map {
   // Custom iterator for the ordered_map object.
   // This iterator should iterate over the keys in the order they were inserted
   template <typename MapType, typename OrderedKeysType>
-  class iterator_base : public std::iterator<std::forward_iterator_tag, 
-                                             typename MapType::value_type> {
+  class iterator_base
+      : public std::iterator<std::forward_iterator_tag, typename MapType::value_type> {
    public:
     iterator_base(MapType& map, OrderedKeysType& keys, size_type index)
         : map_(map), keys_(keys), index_(index) {
@@ -153,7 +153,8 @@ class ordered_map {
     const_iterator_(const Map& map, const OrderedKeys& keys, size_type index)
         : iterator_base<const Map, const OrderedKeys>(map, keys, index) {}
     // Construct a const_iterator from a non-const iterator
-    const_iterator_(const iterator_& it) : iterator_base<const Map, const OrderedKeys>(it.map_, it.keys_, it.index) {}
+    const_iterator_(const iterator_& it)
+        : iterator_base<const Map, const OrderedKeys>(it.map_, it.keys_, it.index) {}
 
     const_reference operator*() const { return *this->map_.find(this->keys_[this->index_]); }
 
@@ -218,17 +219,11 @@ class ordered_map {
   }
   */
 
-  iterator find(const Key& key) {
-    return {map_, keys_, index_helper(key)};
-  }
+  iterator find(const Key& key) { return {map_, keys_, index_helper(key)}; }
 
-  const_iterator find(const Key& key) const {
-    return {map_, keys_, index_helper(key)};
-  }
+  const_iterator find(const Key& key) const { return {map_, keys_, index_helper(key)}; }
 
-  bool contains(const Key& key) const {
-    return map_.contains(key);
-  }
+  bool contains(const Key& key) const { return map_.contains(key); }
 
   const OrderedKeys& keys() const { return keys_; }
   const Map& map() const { return map_; }

--- a/include/flexi_cfg/details/ordered_map.h
+++ b/include/flexi_cfg/details/ordered_map.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cassert>
 #include <deque>
 #include <unordered_map>
 #include <utility>
@@ -18,15 +19,15 @@ class ordered_map {
   OrderedKeys keys_;
 
  public:
-  using key_type = Map::key_type;
-  using value_type = Map::value_type;
-  using mapped_type = Map::mapped_type;
-  using hasher = Map::hasher;
-  using key_equal = Map::key_equal;
-  using allocator_type = Map::allocator_type;
+  using key_type = typename Map::key_type;
+  using value_type = typename Map::value_type;
+  using mapped_type = typename Map::mapped_type;
+  using hasher = typename Map::hasher;
+  using key_equal = typename Map::key_equal;
+  using allocator_type = typename Map::allocator_type;
 
   // Iterator related typedefs
-  using size_type = Map::size_type;
+  using size_type = typename Map::size_type;
   // using reference = ;
   // using const_reference = ;
   // using pointer = ;
@@ -85,7 +86,7 @@ class ordered_map {
    public:
     using iterator_category = std::forward_iterator_tag;
     using difference_type = std::ptrdiff_t;
-    using value_type = Map::value_type;
+    using value_type = typename Map::value_type;
 
     iterator_base(MapType& map, OrderedKeysType& keys, size_type index)
         : map_(map), keys_(keys), index_(index) {
@@ -177,7 +178,6 @@ class ordered_map {
 
   std::pair<iterator, bool> insert(const value_type& x) {
     if (map_.contains(x.first)) {
-      // TODO: Make this return the iterator to the correct element
       return {find(x.first), false};
     }
     auto it = end();
@@ -188,7 +188,6 @@ class ordered_map {
 
   std::pair<iterator, bool> insert(value_type&& x) {
     if (map_.contains(x.first)) {
-      // TODO: Make this return the iterator to the correct element
       return {find(x.first), false};
     }
     auto it = end();
@@ -201,7 +200,6 @@ class ordered_map {
   std::enable_if_t<std::is_convertible_v<value_type, Pair>, std::pair<iterator, bool>> insert(
       Pair&& x) {
     if (map_.contains(x.first)) {
-      // TODO: Make this return the iterator to the correct element
       return {find(x.first), false};
     }
     auto it = end();

--- a/include/flexi_cfg/details/ordered_map.h
+++ b/include/flexi_cfg/details/ordered_map.h
@@ -139,6 +139,9 @@ class ordered_map {
     reference operator*() const { return *this->map_.find(this->keys_[this->index_]); }
 
     pointer operator->() const { return this->map_[this->keys_[this->index_]]; }
+
+   protected:
+    friend class const_iterator_;
   };
 
   // Custom iterator for the ordered_map object.
@@ -150,6 +153,8 @@ class ordered_map {
 
     const_iterator_(const Map& map, const OrderedKeys& keys, size_type index)
         : iterator_base<const Map, const OrderedKeys>(map, keys, index) {}
+    // Construct a const_iterator from a non-const iterator
+    const_iterator_(const iterator_& it) : iterator_base<const Map, const OrderedKeys>(it.map_, it.keys_, it.index) {}
 
     const_reference operator*() const { return *this->map_.find(this->keys_[this->index_]); }
 
@@ -205,15 +210,39 @@ class ordered_map {
     return {it, true};
   }
 
+  void clear() noexcept {
+    map_.clear();
+    keys_.clear();
+  }
+
+  // TODO: IMPLEMENT MERGE
+  /*
+  void merge(...) {
+
+  }
+  */
+
+  iterator find(const Key& key) {
+    return {map_, keys_, index_helper(key)};
+  }
+
+  const_iterator find(const Key& key) const {
+    return {map_, keys_, index_helper(key)};
+  }
+
+  bool contains(const Key& key) const {
+    return map_.contains(key);
+  }
+
   const OrderedKeys& keys() const { return keys_; }
   const Map& map() const { return map_; }
 
  protected:
-  iterator find(const Key& key) {
+  size_t index_helper(const Key& key) const {
     const auto key_it = std::find(std::begin(keys_), std::end(keys_), key);
     const auto idx = std::distance(std::begin(keys_), key_it);
     assert(idx >= 0 && "Expected element idx to be non-negative");
-    return {map_, keys_, static_cast<size_t>(idx)};
+    return static_cast<size_t>(idx);
   }
 };
 

--- a/include/flexi_cfg/details/type_traits.h
+++ b/include/flexi_cfg/details/type_traits.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <memory>
+
+namespace flexi_cfg::details::type_traits {
+  // Similar to 'std::is_pointer<T>' this type trait allows for detection of a smart point
+// (std::unique_ptr, std::shared_ptr, std::weak_ptr)
+template <typename T, typename = void>
+struct is_smart_pointer : std::false_type {};
+
+template <typename T>
+struct is_smart_pointer<
+    T, std::enable_if_t<std::is_same_v<std::decay_t<T>,
+                                       std::unique_ptr<typename std::decay_t<T>::element_type,
+                                                       typename std::decay_t<T>::deleter_type>>>>
+    : std::true_type {};
+
+template <typename T>
+struct is_smart_pointer<
+    T, typename std::enable_if_t<std::is_same_v<
+           std::decay_t<T>, std::shared_ptr<typename std::decay_t<T>::element_type>>>>
+    : std::true_type {};
+
+template <typename T>
+struct is_smart_pointer<
+    T, typename std::enable_if_t<
+           std::is_same_v<std::decay_t<T>, std::weak_ptr<typename std::decay_t<T>::element_type>>>>
+    : std::true_type {};
+
+template <typename T>
+inline constexpr bool is_smart_pointer_v = is_smart_pointer<T>::value;
+}

--- a/include/flexi_cfg/logger.h
+++ b/include/flexi_cfg/logger.h
@@ -7,7 +7,7 @@
 #include <cstdint>
 #include <deque>
 #include <magic_enum.hpp>
-#include <map>
+#include <unordered_map>
 #include <string_view>
 
 namespace flexi_cfg::logger {
@@ -56,7 +56,7 @@ class Logger {
  private:
   Severity log_level_{Severity::INFO};
 
-  const std::map<Severity, fmt::text_style> fg_color_ = {
+  const std::unordered_map<Severity, fmt::text_style> fg_color_ = {
       {Severity::TRACE, fmt::fg(fmt::color::magenta)},
       {Severity::DEBUG, fmt::fg(fmt::color::cyan)},
       {Severity::INFO, fmt::fg(fmt::color::green)},

--- a/include/flexi_cfg/math/actions.h
+++ b/include/flexi_cfg/math/actions.h
@@ -2,6 +2,7 @@
 
 #include <stdexcept>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "flexi_cfg/logger.h"
@@ -26,12 +27,13 @@
 
 namespace flexi_cfg::math {
 
+using VarRefMap = std::unordered_map<std::string, double>;
+
 struct ActionData {
   math::Stacks s{};
 
-  // This could be a `config::types::CfgMap` object, but rather than introduce that dependency,
-  // we'll make it a simple map from strings to values.
-  std::map<std::string, double> var_ref_map{};
+  // Mapping from variable names within expressions to their values.
+  VarRefMap var_ref_map{};
 
   // Track open/close brackets to know when to finalize the result.
   size_t bracket_cnt{0};

--- a/include/flexi_cfg/utils.h
+++ b/include/flexi_cfg/utils.h
@@ -1,12 +1,19 @@
 #pragma once
 
+#if defined(__GNUC__) || defined(__clang__)
+#include <cxxabi.h>
+#endif
+
 #include <iostream>
 #include <iterator>
+#include <memory>
 #include <numeric>
 #include <span>
 #include <sstream>
 #include <string>
 #include <vector>
+
+#include "flexi_cfg/details/type_traits.h"
 
 namespace flexi_cfg::utils {
 /// \brief Removes all instances of any char foundi in `sep` from the beginning and end of `s`
@@ -108,6 +115,44 @@ auto contains(const C& v, const T& x) -> decltype(end(v), true) {
   } else {
     return end(v) != std::find(begin(v), end(v), x);
   }
+}
+
+
+/// \brief Demangles a mangled function/typename into a human-readable name
+/// \param[in] name The object name (often provided by 'typeeid(T).name()')
+/// \return A human-readable function/type name.
+inline std::string demangle(const char* name) {
+  // See https://stackoverflow.com/a/4541470 for source
+
+#if defined(__GNUC__) || defined(__clang__)
+  int status{-1};  // assume __cxa_demangle is unsuccessful
+
+  std::unique_ptr<char, decltype(&std::free)> res{
+      abi::__cxa_demangle(name, nullptr, nullptr, &status), std::free};
+
+  return (status == 0) ? res.get() : name;
+#else
+  // If not supported, return the input name. Support MSVC explicitly?
+  return name;
+#endif
+}
+
+/// \brief Returns the type of an object as a string
+/// \param[in] obj The instance of the object
+/// \return The type of the object as a string
+template <typename T>
+std::string getTypeName(const T& obj) {
+  if constexpr (std::is_pointer_v<T> || details::type_traits::is_smart_pointer_v<T>) {
+    return demangle(typeid(*obj).name());
+  }
+  return demangle(typeid(obj).name());
+}
+
+/// \brief Returns a string representation of a type
+/// \tparam T The type
+template <typename T>
+std::string getTypeName() {
+  return demangle(typeid(T).name());
 }
 
 }  // namespace flexi_cfg::utils

--- a/python/test_flexi_cfg.py
+++ b/python/test_flexi_cfg.py
@@ -52,7 +52,7 @@ class TestMyConfig(unittest.TestCase):
         self.assertEqual(cfg.getBool("test2.bool_key"), expected_cfg["test2"]["bool_key"])
         self.assertEqual(cfg.getFloatList("my_list"), expected_cfg['my_list'])
 
-        self.assertEqual(sorted(cfg.keys()), sorted(expected_cfg.keys()))
+        self.assertEqual(cfg.keys(), list(expected_cfg.keys()))
         self.assertEqual(cfg.getType("test1.key1"), flexi_cfg.Type.kString)
         self.assertEqual(cfg.getType("test1.key2"), flexi_cfg.Type.kNumber)
         self.assertEqual(cfg.getType("test1.key3"), flexi_cfg.Type.kNumber)
@@ -87,7 +87,7 @@ class TestMyConfig(unittest.TestCase):
         
         cfg = flexi_cfg.parse(cfg_file_path)
 
-        self.assertEqual(sorted(cfg.keys()), sorted(expected_cfg.keys()))
+        self.assertEqual(cfg.keys(), list(expected_cfg.keys()))
         self.assertEqual(cfg.getFloat('test1.key3'), cfg.getFloat('test2.var_ref'))
         self.assertAlmostEqual(cfg.getFloat('test1.key3'), expected_cfg['test1']['key3'], places=6)
 

--- a/src/config_helpers.cpp
+++ b/src/config_helpers.cpp
@@ -2,7 +2,6 @@
 
 #include <algorithm>
 #include <iostream>
-#include <map>
 #include <memory>
 #include <range/v3/algorithm/find.hpp>
 #include <range/v3/view/drop_last.hpp>

--- a/src/config_helpers.cpp
+++ b/src/config_helpers.cpp
@@ -64,6 +64,7 @@ auto checkForErrors(const types::CfgMap& cfg1, const types::CfgMap& cfg2, const 
 auto mergeNestedMaps(const types::CfgMap& cfg1, const types::CfgMap& cfg2) -> types::CfgMap {
   const auto common_keys =
       ranges::views::set_intersection(cfg1 | ranges::views::keys, cfg2 | ranges::views::keys);
+  logger::trace("Common keys: {}", common_keys | ranges::views::all);
 
   for (const auto& k : common_keys) {
     checkForErrors(cfg1, cfg2, k);
@@ -74,6 +75,11 @@ auto mergeNestedMaps(const types::CfgMap& cfg1, const types::CfgMap& cfg2) -> ty
   types::CfgMap cfg_out{};
   std::copy(std::begin(cfg1), std::end(cfg1), std::inserter(cfg_out, cfg_out.end()));
   std::copy(std::begin(cfg2), std::end(cfg2), std::inserter(cfg_out, cfg_out.end()));
+  logger::trace("Merged top-level keys: {}", cfg_out | ranges::views::keys);
+  std::vector<std::string> tmp_keys;
+  std::transform(std::begin(cfg_out), std::end(cfg_out), std::back_inserter(tmp_keys),
+                 [](const auto& el) { return el.first; });
+  logger::trace("Merged top-level keys: {}", tmp_keys);
   for (auto& el : cfg_out) {
     const auto& key = el.first;
     if (ranges::find(std::begin(common_keys), std::end(common_keys), key) !=

--- a/src/config_helpers.cpp
+++ b/src/config_helpers.cpp
@@ -113,7 +113,10 @@ auto structFromReference(std::shared_ptr<types::ConfigReference>& ref,
   }
 
   // Next, move the data from the reference to the struct:
-  struct_out->data.merge(ref->data);
+  // struct_out->data.merge(ref->data);
+  struct_out->data.insert(std::make_move_iterator(std::begin(ref->data)), 
+                          std::make_move_iterator(std::end(ref->data)));
+  ref->data.clear();
   if (CONFIG_HELPERS_DEBUG) {
     logger::debug("Data added: \n{}", struct_out);
   }

--- a/src/config_helpers.cpp
+++ b/src/config_helpers.cpp
@@ -62,6 +62,10 @@ auto checkForErrors(const types::CfgMap& cfg1, const types::CfgMap& cfg2, const 
  * Any key/value pairs that already exist in the leaves of cfg1 will be overwritten by the same
  * key/value pairs from cfg2. */
 auto mergeNestedMaps(const types::CfgMap& cfg1, const types::CfgMap& cfg2) -> types::CfgMap {
+  logger::setLevel(logger::Severity::TRACE);
+  logger::debug("Being mergeNestedMaps ---------------------");
+  logger::trace("cfg1 keys: {}", cfg1 | ranges::views::keys);
+  logger::trace("cfg2 keys: {}", cfg2 | ranges::views::keys);
   const auto common_keys =
       ranges::views::set_intersection(cfg1 | ranges::views::keys, cfg2 | ranges::views::keys);
   logger::trace("Common keys: {}", common_keys | ranges::views::all);
@@ -96,7 +100,7 @@ auto mergeNestedMaps(const types::CfgMap& cfg1, const types::CfgMap& cfg2) -> ty
       }
     }
   }
-
+  logger::warn("End mergeNestedMaps ---------------------");
   return cfg_out;
 }
 

--- a/src/config_helpers.cpp
+++ b/src/config_helpers.cpp
@@ -84,7 +84,7 @@ auto mergeNestedMaps(const types::CfgMap& cfg1, const types::CfgMap& cfg2) -> ty
   std::transform(std::begin(cfg_out), std::end(cfg_out), std::back_inserter(tmp_keys),
                  [](const auto& el) { return el.first; });
   logger::trace("Merged top-level keys: {}", tmp_keys);
-  for (auto& el : cfg_out) {
+  for (const auto& el : cfg_out) {
     const auto& key = el.first;
     if (ranges::find(std::begin(common_keys), std::end(common_keys), key) !=
         std::end(common_keys)) {
@@ -118,7 +118,7 @@ auto structFromReference(std::shared_ptr<types::ConfigReference>& ref,
 
   // Next, move the data from the reference to the struct:
   // struct_out->data.merge(ref->data);
-  struct_out->data.insert(std::make_move_iterator(std::begin(ref->data)), 
+  struct_out->data.insert(std::make_move_iterator(std::begin(ref->data)),
                           std::make_move_iterator(std::end(ref->data)));
   ref->data.clear();
   if (CONFIG_HELPERS_DEBUG) {
@@ -201,9 +201,9 @@ void replaceProtoVar(types::CfgMap& cfg_map, const types::RefMap& ref_vars) {
     return ret;
   };
 
-  for (auto& kv : cfg_map) {
+  for (const auto& kv : cfg_map) {
     const auto& k = kv.first;
-    auto& v = kv.second;
+    const auto& v = kv.second;
     if (CONFIG_HELPERS_DEBUG) {
       logger::trace("At: {} = {} | type: {}", k, v, v->type);
     }
@@ -417,7 +417,7 @@ void resolveVarRefs(const types::CfgMap& root, types::CfgMap& sub_tree,
     assert(expression != nullptr);
     logger::trace("Calling resolve_expression_vars with expression={}, src_key={}", expression,
                   src_key);
-    for (auto& kvl : expression->value_lookups) {
+    for (const auto& kvl : expression->value_lookups) {
       if (kvl.second->type == types::Type::kNumber) {
         // We may have already resolved this variable, so no need to do anything
         continue;
@@ -504,7 +504,7 @@ auto evaluateExpression(std::shared_ptr<types::ConfigExpression>& expression,
 }
 
 void evaluateExpressions(types::CfgMap& cfg, const std::string& parent_key) {
-  for (auto& kv : cfg) {
+  for (const auto& kv : cfg) {
     const auto key = utils::makeName(parent_key, kv.first);
     if (kv.second && kv.second->type == types::Type::kExpression) {
       // Evaluate expression
@@ -590,7 +590,7 @@ void unflatten(const std::string& flat_key, types::CfgMap& cfg, std::size_t dept
 
 void cleanupConfig(types::CfgMap& cfg, std::size_t depth) {
   std::vector<std::remove_reference_t<decltype(cfg)>::key_type> to_erase{};
-  for (auto& kv : cfg) {
+  for (const auto& kv : cfg) {
     if (kv.second->type == types::Type::kStruct || kv.second->type == types::Type::kStructInProto) {
       auto s = dynamic_pointer_cast<types::ConfigStruct>(kv.second);
       s->depth = depth;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -124,3 +124,23 @@ target_include_directories(math_test PRIVATE
 
 add_clang_format(math_test)
 gtest_discover_tests(math_test)
+
+################################################################################
+add_executable(
+  ordered_map_test
+  ordered_map_test.cpp
+  )
+
+target_link_libraries(
+  ordered_map_test
+  flexi_cfg
+  fmt::fmt
+  gtest_main
+  )
+
+target_include_directories(ordered_map_test PRIVATE
+  ${PROJECT_SOURCE_DIR}/include/
+  )
+
+add_clang_format(ordered_map_test)
+gtest_discover_tests(ordered_map_test)

--- a/tests/config_helpers_test.cpp
+++ b/tests/config_helpers_test.cpp
@@ -161,6 +161,7 @@ TEST(ConfigHelpers, mergeNestedMaps) {
     }
   }
   {
+    flexi_cfg::logger::error("-----------------------------------------------------");
     // This test should fail due to an exception
     const std::string key = "key";
     const std::vector<std::string> inner_keys = {"key1", "key2", "key3"};
@@ -192,6 +193,7 @@ TEST(ConfigHelpers, mergeNestedMaps) {
     flexi_cfg::config::types::CfgMap cfg_out{};
     EXPECT_THROW(cfg_out = flexi_cfg::config::helpers::mergeNestedMaps(cfg1, cfg2),
                  flexi_cfg::config::DuplicateKeyException);
+    flexi_cfg::logger::error("-----------------------------------------------------");
   }
   {
     // Test a multi-nested map

--- a/tests/math_test.cpp
+++ b/tests/math_test.cpp
@@ -7,7 +7,6 @@
 #include <tao/pegtl/contrib/parse_tree.hpp>
 #include <tao/pegtl/contrib/parse_tree_to_dot.hpp>
 #include <tuple>
-#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -15,10 +14,6 @@
 #include "flexi_cfg/math/grammar.h"
 
 namespace peg = TAO_PEGTL_NAMESPACE;
-
-namespace {
-using RefMap = std::map<std::string, double>;
-}
 
 class MathExpressionTest : public ::testing::Test {
  protected:
@@ -33,7 +28,7 @@ class MathExpressionTest : public ::testing::Test {
       {"  1/3 * -( 5 + 4 )  ", -3.0},
       {"\t3.4 * -(1.9**2 * (1/3.1 - 6) * (2.54- 17.0)\t)", -1007.6399690322581}};
 
-  const std::vector<std::tuple<std::string, double, RefMap>> test_w_var_ref = {
+  const std::vector<std::tuple<std::string, double, flexi_cfg::math::VarRefMap>> test_w_var_ref = {
       {"0.5 * ($(test1.key) - 0.234)", 0.503, {{"test1.key", 1.24}}},
       {"3*$(var_ref1) - 2.3**$(exponent) - 5 * 4",
        -20.70657508881031,
@@ -71,7 +66,7 @@ TEST_F(MathExpressionTest, evaluate) {
 
 // NOLINTNEXTLINE
 TEST_F(MathExpressionTest, evaluate_var_ref) {
-  auto test_input = [](const std::string& input, const RefMap& ref_map) -> double {
+  auto test_input = [](const std::string& input, const flexi_cfg::math::VarRefMap& ref_map) -> double {
     peg::memory_input in(input, "from content");
     flexi_cfg::math::ActionData out;
     out.var_ref_map = ref_map;

--- a/tests/math_test.cpp
+++ b/tests/math_test.cpp
@@ -66,7 +66,8 @@ TEST_F(MathExpressionTest, evaluate) {
 
 // NOLINTNEXTLINE
 TEST_F(MathExpressionTest, evaluate_var_ref) {
-  auto test_input = [](const std::string& input, const flexi_cfg::math::VarRefMap& ref_map) -> double {
+  auto test_input = [](const std::string& input,
+                       const flexi_cfg::math::VarRefMap& ref_map) -> double {
     peg::memory_input in(input, "from content");
     flexi_cfg::math::ActionData out;
     out.var_ref_map = ref_map;

--- a/tests/ordered_map_test.cpp
+++ b/tests/ordered_map_test.cpp
@@ -70,6 +70,42 @@ TEST(OrderedMap, Test) {
   }
 }
 
+TEST(OrderedMap, constructors) {
+  using BasicMap = flexi_cfg::details::ordered_map<int, double>;
+
+  BasicMap empty;
+  EXPECT_TRUE(empty.empty());
+  EXPECT_EQ(empty.size(), 0);
+
+  // Initializer list construction
+  BasicMap map0({{1, 1.0}, {2, 2.0}, {3, 3.0}});
+
+  // Initializer list assignment construction
+  BasicMap map1 = {{1, 1.0}, {2, 2.0}, {3, 3.0}};
+  EXPECT_EQ(map1.size(), 3);
+
+  // Copy constructor
+  BasicMap map2(map1);
+  EXPECT_EQ(map2.size(), 3);
+
+  // Const copy constructor
+  const BasicMap map3_const(map1);
+  EXPECT_EQ(map3_const.size(), 3);
+
+  // Iterator constructor
+  BasicMap map4(std::begin(map1), std::end(map1));
+  EXPECT_EQ(map4.size(), 3);
+
+  // Move constructor
+  BasicMap map3(std::move(map2));
+  EXPECT_EQ(map3.size(), 3);
+
+  // Construct from a std::vector<std::pair<K, V>>
+  std::vector<std::pair<int, double>> vec = {{1, 1.0}, {2, 2.0}, {3, 3.0}};
+  BasicMap map5(std::begin(vec), std::end(vec));
+  EXPECT_EQ(map5.size(), vec.size());
+}
+
 TEST(OrderedMap, order) {
   // Create a map, and ensure that the order is preserved.
   OMap map = {{"this", 0}, {"is", 1},  {"a", 2},      {"test", 3}, {"to", 4},

--- a/tests/ordered_map_test.cpp
+++ b/tests/ordered_map_test.cpp
@@ -1,19 +1,19 @@
-#include <gtest/gtest.h>
+#include "flexi_cfg/details/ordered_map.h"
 
 #include <fmt/format.h>
+#include <gtest/gtest.h>
 
 #include <string>
 
-#include "flexi_cfg/details/ordered_map.h"
 #include "flexi_cfg/utils.h"
 
 namespace {
 using MyMap = std::unordered_map<std::string, int>;
 using OMap = flexi_cfg::details::ordered_map<std::string, int>;
-}
+}  // namespace
 
 namespace fmt {
-    template <>
+template <>
 struct formatter<OMap::value_type> {
   template <typename ParseContext>
   constexpr auto parse(ParseContext& ctx) {
@@ -25,60 +25,72 @@ struct formatter<OMap::value_type> {
     return format_to(ctx.out(), "{} = {}", kv.first, kv.second);
   }
 };
-}
+}  // namespace fmt
 
 TEST(OrderedMap, Test) {
-    OMap map = {
-        {"this", 0},
-        {"is", 1},
-        {"a", 2},
-        {"test", 3},
-        {"to", 4},
-        {"see", 5},
-        {"how", 6},
-        {"things", 7},
-        {"work", 8}
-    };
+  OMap map = {{"this", 0}, {"is", 1},  {"a", 2},      {"test", 3}, {"to", 4},
+              {"see", 5},  {"how", 6}, {"things", 7}, {"work", 8}};
 
-    fmt::print("value_type: {}\n", flexi_cfg::utils::getTypeName<MyMap::value_type>());
+  fmt::print("value_type: {}\n", flexi_cfg::utils::getTypeName<MyMap::value_type>());
 
-    fmt::print("value_type: {}\n", flexi_cfg::utils::getTypeName<OMap::value_type>());
+  fmt::print("value_type: {}\n", flexi_cfg::utils::getTypeName<OMap::value_type>());
 
-    fmt::print("keys: {}\n", fmt::join(map.keys(), ", "));
-    fmt::print("map: \n  {}\n", fmt::join(map.map(), "\n  "));
+  fmt::print("keys: {}\n", fmt::join(map.keys(), ", "));
+  fmt::print("map: \n  {}\n", fmt::join(map.map(), "\n  "));
 
-    fmt::print("----- const iterator check: -----\n");
-    for (const auto& [key, value] : map) {
-        fmt::print("key: {}, value: {}\n", key, value);
+  fmt::print("----- const iterator check: -----\n");
+  for (const auto& [key, value] : map) {
+    fmt::print("key: {}, value: {}\n", key, value);
+  }
+
+  fmt::print("----- non-const iterator check: -----\n");
+  for (auto& [key, value] : map) {
+    fmt::print("key: {}, value: {}\n", key, value);
+  }
+
+  {  // Insertion test. Need to test the other signatures of this call.
+    auto ret = map.insert(OMap::value_type{"new 1", -1});
+    fmt::print("success: {}, it: {}\n", ret.second, *ret.first);
+    auto fail = map.insert(OMap::value_type{"test", -1});
+    fmt::print("Success: {}, it: {}\n", fail.second, *fail.first);
+    auto ret2 = map.insert(OMap::value_type{"see", -1});
+    fmt::print("success: {}, it: {}\n", ret2.second, *ret2.first);
+  }
+
+  {
+    MyMap test = {{"a", 0}, {"b", 1}, {"c", 2}};
+    auto suc = test.insert({"d", 3});
+    fmt::print("success: {}, it: {}\n", suc.second, *suc.first);
+    auto fail = test.insert({"b", 4});
+    fmt::print("success: {}, ", fail.second);
+    if (fail.first != std::end(test)) {
+      fmt::print("it: {}", *fail.first);
     }
+    fmt::print("\n");
+  }
+}
 
-    fmt::print("----- non-const iterator check: -----\n");
-    for (auto& [key, value] : map) {
-        fmt::print("key: {}, value: {}\n", key, value);
+TEST(OrderedMap, insert) {
+  OMap map = {{"this", 0}, {"is", 1},  {"a", 2},      {"test", 3}, {"to", 4},
+              {"see", 5},  {"how", 6}, {"things", 7}, {"work", 8}};
+  {  // Insertion test. Need to test the other signatures of this call.
+    auto ret = map.insert(OMap::value_type{"new 1", -1});
+    fmt::print("success: {}, it: {}\n", ret.second, *ret.first);
+    auto fail = map.insert(OMap::value_type{"test", -1});
+    fmt::print("Success: {}, it: {}\n", fail.second, *fail.first);
+    auto ret2 = map.insert(OMap::value_type{"see", -1});
+    fmt::print("success: {}, it: {}\n", ret2.second, *ret2.first);
+  }
+
+  {
+    MyMap test = {{"a", 0}, {"b", 1}, {"c", 2}};
+    auto suc = test.insert({"d", 3});
+    fmt::print("success: {}, it: {}\n", suc.second, *suc.first);
+    auto fail = test.insert({"b", 4});
+    fmt::print("success: {}, ", fail.second);
+    if (fail.first != std::end(test)) {
+      fmt::print("it: {}", *fail.first);
     }
-
-    { // Insertion test. Need to test the other signatures of this call.
-        auto ret = map.insert(OMap::value_type{"new 1", -1});
-        fmt::print("success: {}, it: {}\n", ret.second, *ret.first);
-        auto fail = map.insert(OMap::value_type{"test", -1});
-        fmt::print("Success: {}, it: {}\n", fail.second, *fail.first);
-        auto ret2 = map.insert(OMap::value_type{"see", -1});
-        fmt::print("success: {}, it: {}\n", ret2.second, *ret2.first);
-
-    }
-
-
-
-
-    {
-        MyMap test = { {"a", 0}, {"b", 1}, {"c", 2} };
-        auto suc = test.insert({"d", 3});
-        fmt::print("success: {}, it: {}\n", suc.second, *suc.first);
-        auto fail = test.insert({"b", 4});
-        fmt::print("success: {}, ", fail.second);
-        if (fail.first != std::end(test)) {
-            fmt::print("it: {}", *fail.first);
-        }
-        fmt::print("\n");
-    }
+    fmt::print("\n");
+  }
 }

--- a/tests/ordered_map_test.cpp
+++ b/tests/ordered_map_test.cpp
@@ -70,27 +70,61 @@ TEST(OrderedMap, Test) {
   }
 }
 
+TEST(OrderedMap, order) {
+  // Create a map, and ensure that the order is preserved.
+  OMap map = {{"this", 0}, {"is", 1},  {"a", 2},      {"test", 3}, {"to", 4},
+              {"see", 5},  {"how", 6}, {"things", 7}, {"work", 8}};
+  std::vector<std::string> expected_keys = {"this", "is",  "a",      "test", "to",
+                                            "see",  "how", "things", "work"};
+  for (const auto& [key, idx] : map) {
+    EXPECT_EQ(key, expected_keys[idx]);
+  }
+}
+
+TEST(OrderedMap, iterators) {
+  std::vector<std::string> expected_keys = {"this", "is",  "a",      "test", "to",
+                                            "see",  "how", "things", "work"};
+  auto build_map = [](const std::vector<std::string>& keys) {
+    OMap map;
+    for (size_t i = 0; i < keys.size(); ++i) {
+      map.insert({keys[i], i});
+    }
+    return map;
+  };
+  {
+    OMap map = build_map(expected_keys);
+    for (auto it = map.begin(); it != map.end(); ++it) {
+      EXPECT_EQ(it->first, expected_keys[it->second]);
+      EXPECT_EQ(std::distance(std::begin(map), it), it->second);
+    }
+  }
+  {
+    const OMap map = build_map(expected_keys);
+    for (auto it = map.begin(); it != map.end(); ++it) {
+      EXPECT_EQ(it->first, expected_keys[it->second]);
+      EXPECT_EQ(std::distance(std::begin(map), it), it->second);
+    }
+  }
+}
+
 TEST(OrderedMap, insert) {
   OMap map = {{"this", 0}, {"is", 1},  {"a", 2},      {"test", 3}, {"to", 4},
               {"see", 5},  {"how", 6}, {"things", 7}, {"work", 8}};
-  {  // Insertion test. Need to test the other signatures of this call.
-    auto ret = map.insert(OMap::value_type{"new 1", -1});
-    fmt::print("success: {}, it: {}\n", ret.second, *ret.first);
-    auto fail = map.insert(OMap::value_type{"test", -1});
-    fmt::print("Success: {}, it: {}\n", fail.second, *fail.first);
-    auto ret2 = map.insert(OMap::value_type{"see", -1});
-    fmt::print("success: {}, it: {}\n", ret2.second, *ret2.first);
-  }
-
   {
-    MyMap test = {{"a", 0}, {"b", 1}, {"c", 2}};
-    auto suc = test.insert({"d", 3});
-    fmt::print("success: {}, it: {}\n", suc.second, *suc.first);
-    auto fail = test.insert({"b", 4});
-    fmt::print("success: {}, ", fail.second);
-    if (fail.first != std::end(test)) {
-      fmt::print("it: {}", *fail.first);
-    }
-    fmt::print("\n");
+    // Insert a new element. Check that it succeeds and that the returned iterator points to the new
+    // element.
+    const auto& ret = map.insert(OMap::value_type{"new 1", -1});
+    EXPECT_TRUE(ret.second);
+    const auto& it = ret.first;
+    EXPECT_EQ(it->first, "new 1");
+    EXPECT_EQ(it->second, -1);
+  }
+  {
+    // Attempt to insert and element with a key that already exists. Check that it fails and that
+    // the returned iterator points to the existing element.
+    auto fail = map.insert(OMap::value_type{"test", -1});
+    EXPECT_FALSE(fail.second);
+    EXPECT_EQ(fail.first->first, "test");
+    EXPECT_EQ(fail.first->second, 3);
   }
 }

--- a/tests/ordered_map_test.cpp
+++ b/tests/ordered_map_test.cpp
@@ -1,0 +1,84 @@
+#include <gtest/gtest.h>
+
+#include <fmt/format.h>
+
+#include <string>
+
+#include "flexi_cfg/details/ordered_map.h"
+#include "flexi_cfg/utils.h"
+
+namespace {
+using MyMap = std::unordered_map<std::string, int>;
+using OMap = flexi_cfg::details::ordered_map<std::string, int>;
+}
+
+namespace fmt {
+    template <>
+struct formatter<OMap::value_type> {
+  template <typename ParseContext>
+  constexpr auto parse(ParseContext& ctx) {
+    return ctx.begin();
+  }
+
+  template <typename FormatContext>
+  auto format(const OMap::value_type& kv, FormatContext& ctx) const {
+    return format_to(ctx.out(), "{} = {}", kv.first, kv.second);
+  }
+};
+}
+
+TEST(OrderedMap, Test) {
+    OMap map = {
+        {"this", 0},
+        {"is", 1},
+        {"a", 2},
+        {"test", 3},
+        {"to", 4},
+        {"see", 5},
+        {"how", 6},
+        {"things", 7},
+        {"work", 8}
+    };
+
+    fmt::print("value_type: {}\n", flexi_cfg::utils::getTypeName<MyMap::value_type>());
+
+    fmt::print("value_type: {}\n", flexi_cfg::utils::getTypeName<OMap::value_type>());
+
+    fmt::print("keys: {}\n", fmt::join(map.keys(), ", "));
+    fmt::print("map: \n  {}\n", fmt::join(map.map(), "\n  "));
+
+    fmt::print("----- const iterator check: -----\n");
+    for (const auto& [key, value] : map) {
+        fmt::print("key: {}, value: {}\n", key, value);
+    }
+
+    fmt::print("----- non-const iterator check: -----\n");
+    for (auto& [key, value] : map) {
+        fmt::print("key: {}, value: {}\n", key, value);
+    }
+
+    { // Insertion test. Need to test the other signatures of this call.
+        auto ret = map.insert(OMap::value_type{"new 1", -1});
+        fmt::print("success: {}, it: {}\n", ret.second, *ret.first);
+        auto fail = map.insert(OMap::value_type{"test", -1});
+        fmt::print("Success: {}, it: {}\n", fail.second, *fail.first);
+        auto ret2 = map.insert(OMap::value_type{"see", -1});
+        fmt::print("success: {}, it: {}\n", ret2.second, *ret2.first);
+
+    }
+
+
+
+
+    {
+        MyMap test = { {"a", 0}, {"b", 1}, {"c", 2} };
+        auto suc = test.insert({"d", 3});
+        fmt::print("success: {}, it: {}\n", suc.second, *suc.first);
+        auto fail = test.insert({"b", 4});
+        fmt::print("success: {}, ", fail.second);
+        if (fail.first != std::end(test)) {
+            fmt::print("it: {}", *fail.first);
+        }
+        fmt::print("\n");
+    }
+}


### PR DESCRIPTION
*  Implements a custom 'ordered_map' container that holds the order of the elements in a consistent (insertion) order.

WIP