### PR TITLE
Fix include path handling in nested includes

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -133,7 +133,7 @@ jobs:
       run: |
         ctest -C ${{env.BUILD_TYPE}}
         ${{github.workspace}}/build/src/include_file_test
-        for i in `seq 1 11`; do
+        for i in `seq 1 12`; do
           ${{github.workspace}}/build/src/config_build ${{github.workspace}}/examples/config_example$i.cfg
         done
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ In summary, a `proto` that is `reference`d, effectively becomes a `struct`.
    another file. This highlights one of the advantages of this syntax: the ability to
    define a generic set of templates in one file, which will be used to produce multiple,
    repeated concrete structs with different names and parameters in a different file.
+2. `include_relative` syntax - Same as `include`, except nested paths will resolve from the
+   included file's path instead of from the base file's path. See `examples/config_example12.cfg`
+   for an example of this keyword. The list of `include_relative` statements must come after all `include`
+   statements in a config file.
 2. [key-value reference](#key-value-references) - Much like bash, the syntax provides the ability
    to reference apreviously defined value by its key, and assign it to another key.
 3. Appended keys - While a `proto` defines a templated `struct`, one can add additional keys

--- a/examples/config_example12.cfg
+++ b/examples/config_example12.cfg
@@ -1,7 +1,8 @@
 # This example tests multiple levels of nested includes.
 # It tests that the include paths are correct in multiple nested includes, such that
 # parsing from any one file in an include chain is valid.
-include nested/config_nested1.cfg
 include config_example9.cfg
+include config_example10.cfg
+include_relative nested/config_nested1.cfg
 
 dummy = 1 # This dummy variable is required because flexi_cfg cannot handle files that only consist of includes

--- a/examples/config_example12.cfg
+++ b/examples/config_example12.cfg
@@ -1,0 +1,7 @@
+# This example tests multiple levels of nested includes.
+# It tests that the include paths are correct in multiple nested includes, such that
+# parsing from any one file in an include chain is valid.
+include nested/config_nested1.cfg
+include config_example9.cfg
+
+dummy = 1 # This dummy variable is required because flexi_cfg cannot handle files that only consist of includes

--- a/examples/nested/config_nested1.cfg
+++ b/examples/nested/config_nested1.cfg
@@ -1,0 +1,3 @@
+# First level of nested include
+include config_nested2.cfg
+include ../config_example2.cfg

--- a/examples/nested/config_nested1.cfg
+++ b/examples/nested/config_nested1.cfg
@@ -1,3 +1,3 @@
 # First level of nested include
-include config_nested2.cfg
 include ../config_example2.cfg
+include_relative config_nested2.cfg

--- a/examples/nested/config_nested2.cfg
+++ b/examples/nested/config_nested2.cfg
@@ -1,4 +1,4 @@
 # Second level of nested include
 
 # Including this file will also include config_example6.cfg
-include ../config_example5.cfg
+include_relative ../config_example5.cfg

--- a/examples/nested/config_nested2.cfg
+++ b/examples/nested/config_nested2.cfg
@@ -1,0 +1,4 @@
+# Second level of nested include
+
+# Including this file will also include config_example6.cfg
+include ../config_example5.cfg

--- a/include/flexi_cfg/config/actions.h
+++ b/include/flexi_cfg/config/actions.h
@@ -378,8 +378,13 @@ struct action<INCLUDE> {
     try {
       const auto cfg_file = std::filesystem::path(out.base_dir) / out.result;
       peg::file_input include_file(cfg_file);
+      // Update base dir to point to base of included file
+      auto temp_base_dir = out.base_dir;
+      out.base_dir = cfg_file.parent_path().string();
       logger::info("nested parse: {}", include_file.source());
       peg::parse_nested<config::grammar, config::action>(in.position(), include_file, out);
+      // After nested parsing returns, revert base dir
+      out.base_dir = temp_base_dir;
     } catch (const std::system_error& e) {
       throw peg::parse_error("Include error", in.position());
     }

--- a/include/flexi_cfg/config/grammar.h
+++ b/include/flexi_cfg/config/grammar.h
@@ -168,10 +168,15 @@ struct STRUCTc : peg::plus<peg::sor<PAIR, STRUCT, REFERENCE, PROTO>> {};
 struct INCLUDE : peg::seq<TAO_PEGTL_KEYWORD("include"), SP, filename::grammar, TAIL> {};
 struct include_list : peg::star<INCLUDE> {};
 
+// Include relative syntax
+struct INCLUDE_RELATIVE : peg::seq<TAO_PEGTL_KEYWORD("include_relative"), SP, filename::grammar, TAIL> {};
+struct include_relative_list : peg::star<INCLUDE_RELATIVE> {};
+
 // A single file should look like this:
 //
 //  1. Optional list of include files
-//  2. Elements of a config file: flat keys OR struct / proto / reference / pair
+//  2. Optional list of relative include files
+//  3. Elements of a config file: flat keys OR struct / proto / reference / pair
 
 // The `peg::sor<...>` here matches one or more `FULLPAIR` objects or the contents of a `STRUCT`,
 // which includes the following items:
@@ -184,7 +189,7 @@ struct include_list : peg::star<INCLUDE> {};
 // `STRUCTc` from being matched as a `FULLPAIR` object.
 
 struct CONFIG
-    : peg::seq<TAIL, include_list,
+    : peg::seq<TAIL, include_list, include_relative_list,
                peg::sor<peg::seq<peg::not_at<PAIR>, peg::plus<FULLPAIR>>, STRUCTc>, TAIL> {};
 
 struct grammar : peg::seq<CONFIG, peg::eolf> {};

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -38,7 +38,7 @@ if (NOT(${CMAKE_SYSTEM_NAME} MATCHES "Darwin"))
   add_custom_command(
     OUTPUT ${PROJECT_NAME}/__init__.pyi
     COMMAND export PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}
-    COMMAND pybind11-stubgen --root-module-suffix '' --no-setup-py -o ${CMAKE_CURRENT_BINARY_DIR} flexi_cfg
+    COMMAND pybind11-stubgen --root-suffix '' -o ${CMAKE_CURRENT_BINARY_DIR} flexi_cfg
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     DEPENDS flexi_cfg_py
   )


### PR DESCRIPTION
* Adds new keyword `include_relative` to allow nested includes to resolve paths relatively
* Adds nested include test
* Removes deprecated pybind11-stubgen CLI arguments