### PR TITLE
Support environment variables in include statements

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -131,6 +131,7 @@ jobs:
       # Execute tests defined by the CMake configuration.
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       run: |
+        export TEST_DIR=env
         ctest -C ${{env.BUILD_TYPE}}
         ${{github.workspace}}/build/src/include_file_test
         for i in `seq 1 13`; do

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -133,7 +133,7 @@ jobs:
       run: |
         ctest -C ${{env.BUILD_TYPE}}
         ${{github.workspace}}/build/src/include_file_test
-        for i in `seq 1 12`; do
+        for i in `seq 1 13`; do
           ${{github.workspace}}/build/src/config_build ${{github.workspace}}/examples/config_example$i.cfg
         done
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ In summary, a `proto` that is `reference`d, effectively becomes a `struct`.
    included file's path instead of from the base file's path. See `examples/config_example12.cfg`
    for an example of this keyword. The list of `include_relative` statements must come after all `include`
    statements in a config file.
+3. Environment variables - Environment variables may be referenced `include` or `include_relative` statements
+   using the syntax `${ENV_VAR_NAME}`. If the environment variable is not set, the reference
+   will be replaced with an empty string.
 2. [key-value reference](#key-value-references) - Much like bash, the syntax provides the ability
    to reference apreviously defined value by its key, and assign it to another key.
 3. Appended keys - While a `proto` defines a templated `struct`, one can add additional keys

--- a/examples/config_example13.cfg
+++ b/examples/config_example13.cfg
@@ -1,0 +1,7 @@
+include ${TEST_DIR}/env_example1.cfg
+include_relative ${TEST_DIR}/env_example2.cfg
+
+struct test_struct {
+    var_ref1 = $(test1.key1)
+    var_ref2 = $(test1.key2)
+}

--- a/examples/env/env_example1.cfg
+++ b/examples/env/env_example1.cfg
@@ -1,0 +1,1 @@
+test1.key1 = "test"

--- a/examples/env/env_example2.cfg
+++ b/examples/env/env_example2.cfg
@@ -1,0 +1,1 @@
+test1.key2 = "test"

--- a/include/flexi_cfg/config/actions.h
+++ b/include/flexi_cfg/config/actions.h
@@ -376,6 +376,9 @@ struct action<INCLUDE> {
   static void apply(const ActionInput& in, ActionData& out) {
     CONFIG_ACTION_DEBUG("Found include file: {}", out.result);
     try {
+      // Substitute any environment variables in the filename
+      out.result = utils::substituteEnvVars(out.result);
+      CONFIG_ACTION_DEBUG("Include file after env var substitution: {}", out.result);
       const auto cfg_file = std::filesystem::path(out.base_dir) / out.result;
       peg::file_input include_file(cfg_file);
       logger::info("nested parse: {}", include_file.source());
@@ -392,6 +395,9 @@ struct action<INCLUDE_RELATIVE> {
   static void apply(const ActionInput& in, ActionData& out) {
     CONFIG_ACTION_DEBUG("Found relative include file: {}", out.result);
     try {
+      // Substitute any environment variables in the filename
+      out.result = utils::substituteEnvVars(out.result);
+      CONFIG_ACTION_DEBUG("Relative include file after env var substitution: {}", out.result);
       const auto cfg_file = std::filesystem::path(out.base_dir) / out.result;
       peg::file_input include_file(cfg_file);
       // Update base dir to point to base of included file

--- a/include/flexi_cfg/config/grammar.h
+++ b/include/flexi_cfg/config/grammar.h
@@ -21,7 +21,9 @@ struct SEP : peg::one<'/'> {};
 // There may be other valid characters in a filename. What might they be?
 struct ALPHAPLUS : peg::plus<peg::sor<peg::identifier_other, peg::one<'-'>>> {};
 
-struct FILEPART : peg::sor<DOTDOT, ALPHAPLUS> {};
+struct ENVIRONMENT_VAR : peg::seq<peg::one<'$'>, peg::one<'{'>,
+                                  peg::star<peg::sor<peg::alnum, peg::one<'_'>>>, peg::one<'}'>> {};
+struct FILEPART : peg::sor<ENVIRONMENT_VAR, DOTDOT, ALPHAPLUS> {};
 struct FILENAME : peg::seq<peg::list<FILEPART, SEP>, EXT> {};
 
 struct grammar : peg::must<FILENAME> {};

--- a/include/flexi_cfg/config/selector.h
+++ b/include/flexi_cfg/config/selector.h
@@ -31,7 +31,7 @@ struct selector<INCLUDE> : std::true_type {
         logger::debug("  Content: {}", c->string_view());
       }
       if (c->is_type<filename::FILENAME>()) {
-        filename = c->string();
+        filename = utils::substituteEnvVars(c->string());
       }
     }
     std::cout << std::endl;

--- a/include/flexi_cfg/utils.h
+++ b/include/flexi_cfg/utils.h
@@ -11,7 +11,7 @@
 namespace flexi_cfg::utils {
 /// \brief Removes all instances of any char foundi in `sep` from the beginning and end of `s`
 /// \param[in] s - Input string
-/// \paarm[in] sep - A string containing all `char`s to trim
+/// \param[in] sep - A string containing all `char`s to trim
 /// \return The trimmed string
 inline auto trim(std::string s, const std::string& chars = " \n\t\v\r\f") -> std::string {
   std::string str(std::move(s));
@@ -108,6 +108,32 @@ auto contains(const C& v, const T& x) -> decltype(end(v), true) {
   } else {
     return end(v) != std::find(begin(v), end(v), x);
   }
+}
+
+// Substitute all environment variables in the string until there are none left.
+inline auto substituteEnvVars(const std::string& s) -> std::string {
+  std::string str(s);
+  while (true) {
+    const auto pos = str.find("${");
+    if (pos == std::string::npos) {
+      break;
+    }
+
+    const auto end_pos = str.find('}', pos);
+    if (end_pos == std::string::npos) {
+      throw std::runtime_error("Invalid environment variable syntax");
+    }
+
+    const auto var_name = str.substr(pos + 2, end_pos - pos - 2);
+    const auto var_value = std::getenv(var_name.c_str());
+    if (var_value == nullptr) {
+      str.replace(pos, end_pos - pos + 1, "");
+    }
+    else {
+      str.replace(pos, end_pos - pos + 1, var_value);
+    }    
+  }
+  return str;
 }
 
 }  // namespace flexi_cfg::utils

--- a/src/config_helpers.cpp
+++ b/src/config_helpers.cpp
@@ -153,7 +153,7 @@ auto replaceVarInStr(std::string input, const types::RefMap& ref_vars)
     // Strip off any leading or trailing quotes from the replacement value. If the replacement
     // value is not a string, this is a no-op.
     const auto replacement = utils::trim(rv->value, "\\\"");
-    // Look for `rk` (escape leadding '$') in `out` and replace them with 'replacement'
+    // Look for `rk` (escape leading '$') in `out` and replace them with 'replacement'
     out = std::regex_replace(out, std::regex(std::string("\\").append(rk)), replacement);
     // Turn the $VAR version into ${VAR} in case that is used within a string as well. Throw
     // in escape characters as this will be used in a regular expression.

--- a/tests/config_exception_test.cpp
+++ b/tests/config_exception_test.cpp
@@ -44,7 +44,11 @@ TEST(ConfigException, ParseError) {
         "struct test1 {                                                      \n\
            bar = 0                                                           \n\
          }                                                                   \n\
-         foo.bar = 1   # Can't mix flat keys with struct in same file."};
+         foo.bar = 1   # Can't mix flat keys with struct in same file.",
+        "include foo.cfg    # File does not exist",
+        "include_relative foo.cfg    # File does not exist",
+        "include ${abc    # Missing end curly brace",
+        "include_relative ${abc     # Missing end curly brace"};
     for (const auto& input : parse_error) {
       peg::memory_input in_cfg(input, "From content");
       EXPECT_THROW(parse(in_cfg), peg::parse_error) << "Input file: " << in_cfg.source();


### PR DESCRIPTION
Added support for environment variables in include statements using the syntax: `${VAR}`