### PR TITLE
Adds support for specifying the root of the config directory

### DIFF
--- a/examples/config_root/test/config_example_base.cfg
+++ b/examples/config_root/test/config_example_base.cfg
@@ -1,0 +1,4 @@
+
+include nested/config_nested3.cfg
+include config_example12.cfg
+include_relative config_relative.cfg

--- a/examples/config_root/test/config_relative.cfg
+++ b/examples/config_root/test/config_relative.cfg
@@ -1,0 +1,6 @@
+
+
+struct relative {
+    test = 1
+    foo = "bar"
+}

--- a/examples/nested/config_nested3.cfg
+++ b/examples/nested/config_nested3.cfg
@@ -1,0 +1,15 @@
+
+# A bunch of flat keys in a file in a sub-directory
+
+outer.fl.hx.position.foo = 0
+outer.fl.hy.position.foo = 0
+outer.fl.kn.position.foo = 0
+outer.fr.hx.position.foo = 0
+outer.fr.hy.position.foo = 0
+outer.fr.kn.position.foo = 0
+outer.hl.hx.position.foo = 0
+outer.hl.hy.position.foo = 0
+outer.hl.kn.position.foo = 0
+outer.hr.hx.position.foo = 0
+outer.hr.hy.position.foo = 0
+outer.hr.kn.position.foo = 0

--- a/include/flexi_cfg/config/actions.h
+++ b/include/flexi_cfg/config/actions.h
@@ -398,11 +398,11 @@ struct action<INCLUDE_RELATIVE> {
       // Substitute any environment variables in the filename
       out.result = utils::substituteEnvVars(out.result);
       CONFIG_ACTION_DEBUG("Relative include file after env var substitution: {}", out.result);
-      const auto cfg_file = std::filesystem::path(out.base_dir) / out.result;
+      const auto cfg_file = out.base_dir / out.result;
       peg::file_input include_file(cfg_file);
       // Update base dir to point to base of included file
       auto temp_base_dir = out.base_dir;
-      out.base_dir = cfg_file.parent_path().string();
+      out.base_dir = cfg_file.parent_path();
       logger::info("nested parse: {}", include_file.source());
       peg::parse_nested<config::grammar, config::action>(in.position(), include_file, out);
       // After nested parsing returns, revert base dir

--- a/include/flexi_cfg/config/actions.h
+++ b/include/flexi_cfg/config/actions.h
@@ -43,7 +43,7 @@ constexpr std::string_view DEFAULT_RES{"***"};
 struct ActionData {
   int depth{0};  // Nesting level
 
-  std::string base_dir{};
+  std::filesystem::path base_dir{};
   std::string result{DEFAULT_RES};
   std::vector<std::string> keys;
   std::vector<std::string> flat_keys;
@@ -379,7 +379,7 @@ struct action<INCLUDE> {
       // Substitute any environment variables in the filename
       out.result = utils::substituteEnvVars(out.result);
       CONFIG_ACTION_DEBUG("Include file after env var substitution: {}", out.result);
-      const auto cfg_file = std::filesystem::path(out.base_dir) / out.result;
+      const auto cfg_file = out.base_dir / out.result;
       peg::file_input include_file(cfg_file);
       logger::info("nested parse: {}", include_file.source());
       peg::parse_nested<config::grammar, config::action>(in.position(), include_file, out);

--- a/include/flexi_cfg/parser.h
+++ b/include/flexi_cfg/parser.h
@@ -14,10 +14,11 @@ namespace flexi_cfg {
 
 class Parser {
  public:
-  static auto parse(const std::filesystem::path& cfg_filename, 
+  static auto parse(const std::filesystem::path& cfg_filename,
                     std::optional<std::filesystem::path> root_dir = std::nullopt) -> Reader;
 
-  static auto parseFromString(std::string_view cfg_string, std::string_view source = "unknown") -> Reader;
+  static auto parseFromString(std::string_view cfg_string, std::string_view source = "unknown")
+      -> Reader;
 
  private:
   Parser() = default;
@@ -45,12 +46,14 @@ class Parser {
   config::types::CfgMap cfg_data_;
 };
 
-inline auto parse(const std::filesystem::path& cfg_filename) -> Reader {
-  return Parser::parse(cfg_filename);
+inline auto parse(const std::filesystem::path& cfg_filename,
+                  std::optional<std::filesystem::path> root_dir = std::nullopt) -> Reader {
+  return Parser::parse(cfg_filename, root_dir);
 }
 
-inline auto parse(std::string_view cfg_string, std::string_view source = "unknown") -> Reader {
-  return Parser::parse(cfg_string, source);
+inline auto parseFromString(std::string_view cfg_string, std::string_view source = "unknown")
+    -> Reader {
+  return Parser::parseFromString(cfg_string, source);
 }
 
 }  // namespace flexi_cfg

--- a/include/flexi_cfg/parser.h
+++ b/include/flexi_cfg/parser.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <filesystem>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -13,9 +14,10 @@ namespace flexi_cfg {
 
 class Parser {
  public:
-  static auto parse(const std::filesystem::path& cfg_filename) -> Reader;
+  static auto parse(const std::filesystem::path& cfg_filename, 
+                    std::optional<std::filesystem::path> root_dir = std::nullopt) -> Reader;
 
-  static auto parse(std::string_view cfg_string, std::string_view source = "unknown") -> Reader;
+  static auto parseFromString(std::string_view cfg_string, std::string_view source = "unknown") -> Reader;
 
  private:
   Parser() = default;

--- a/python/flexi_cfg_py.cpp
+++ b/python/flexi_cfg_py.cpp
@@ -140,19 +140,19 @@ PYBIND11_MODULE(flexi_cfg, m) {
 
   py::class_<Type> type_holder(m, "Type");
   py::enum_<flexi_cfg::config::types::Type>(type_holder, "Type")
-      .value("kValue", flexi_cfg::config::types::Type::kValue)
-      .value("kString", flexi_cfg::config::types::Type::kString)
-      .value("kNumber", flexi_cfg::config::types::Type::kNumber)
-      .value("kBoolean", flexi_cfg::config::types::Type::kBoolean)
-      .value("kList", flexi_cfg::config::types::Type::kList)
-      .value("kExpression", flexi_cfg::config::types::Type::kExpression)
-      .value("kValueLookup", flexi_cfg::config::types::Type::kValueLookup)
-      .value("kVar", flexi_cfg::config::types::Type::kVar)
-      .value("kStruct", flexi_cfg::config::types::Type::kStruct)
-      .value("kStructInProto", flexi_cfg::config::types::Type::kStructInProto)
-      .value("kProto", flexi_cfg::config::types::Type::kProto)
-      .value("kReference", flexi_cfg::config::types::Type::kReference)
-      .value("kUnknown", flexi_cfg::config::types::Type::kUnknown)
+      .value("VALUE", flexi_cfg::config::types::Type::kValue)
+      .value("STRING", flexi_cfg::config::types::Type::kString)
+      .value("NUMBER", flexi_cfg::config::types::Type::kNumber)
+      .value("BOOLEAN", flexi_cfg::config::types::Type::kBoolean)
+      .value("LIST", flexi_cfg::config::types::Type::kList)
+      .value("EXPRESSION", flexi_cfg::config::types::Type::kExpression)
+      .value("VALUE_LOOKUP", flexi_cfg::config::types::Type::kValueLookup)
+      .value("VAR", flexi_cfg::config::types::Type::kVar)
+      .value("STRUCT", flexi_cfg::config::types::Type::kStruct)
+      .value("STRUCT_IN_PROTO", flexi_cfg::config::types::Type::kStructInProto)
+      .value("PROTO", flexi_cfg::config::types::Type::kProto)
+      .value("REFERENCE", flexi_cfg::config::types::Type::kReference)
+      .value("UNKNOWN", flexi_cfg::config::types::Type::kUnknown)
       .export_values();
 
   auto pyFlexiCfgException =
@@ -182,33 +182,33 @@ PYBIND11_MODULE(flexi_cfg, m) {
       .def("dump", &flexi_cfg::Reader::dump)
       .def("exists", &flexi_cfg::Reader::exists)
       .def("keys", &flexi_cfg::Reader::keys)
-      .def("getType", &flexi_cfg::Reader::getType)
-      .def("findStructWithKey", &flexi_cfg::Reader::findStructsWithKey)
+      .def("get_type", &flexi_cfg::Reader::getType)
+      .def("find_struct_with_key", &flexi_cfg::Reader::findStructsWithKey)
       // Accessors for single values
-      .def("getInt", &getValueHelper<int64_t>)
-      .def("getUint64", &getValueHelper<uint64_t>)
-      .def("getFloat", &getValueHelper<double>)
-      .def("getBool", &getValueHelper<bool>)
-      .def("getString", &getValueHelper<std::string>)
+      .def("get_int", &getValueHelper<int64_t>)
+      .def("get_uint64", &getValueHelper<uint64_t>)
+      .def("get_float", &getValueHelper<double>)
+      .def("get_bool", &getValueHelper<bool>)
+      .def("get_string", &getValueHelper<std::string>)
       // Accessors for lists of values
-      .def("getIntList", &getListHelper<int64_t>)
-      .def("getUint64List", &getListHelper<uint64_t>)
-      .def("getFloatList", &getListHelper<double>)
-      .def("getBoolList", &getListHelper<bool>)
-      .def("getStringList", &getListHelper<std::string>)
+      .def("get_int_list", &getListHelper<int64_t>)
+      .def("get_uint64_list", &getListHelper<uint64_t>)
+      .def("get_float_list", &getListHelper<double>)
+      .def("get_bool_list", &getListHelper<bool>)
+      .def("get_string_list", &getListHelper<std::string>)
       // Accessor for a sub-reader object
-      .def("getReader", &getValueHelper<flexi_cfg::Reader>)
+      .def("get_reader", &getValueHelper<flexi_cfg::Reader>)
       // Generic accessor
-      .def("getValue", &getValueGeneric);
+      .def("get_value", &getValueGeneric);
 
   py::class_<flexi_cfg::Parser>(m, "Parser")
       .def_static("parse", &flexi_cfg::Parser::parse, py::arg("cfg_file"), py::arg("root_dir") = std::nullopt)
-      .def_static("parseFromString",
+      .def_static("parse_from_string",
                   &flexi_cfg::Parser::parseFromString,
                   py::arg("cfg_string"), py::pos_only(), py::arg("source") = "unknown");
 
-  m.def("parse", py::overload_cast<const std::filesystem::path&>(&flexi_cfg::parse));
-  m.def("parse", py::overload_cast<std::string_view, std::string_view>(&flexi_cfg::parse),
+  m.def("parse", &flexi_cfg::parse, py::arg("cfg_file"), py::arg("root_dir") = std::nullopt);
+  m.def("parse_from_string", &flexi_cfg::parseFromString,
         py::arg("cfg_string"), py::pos_only(), py::arg("source") = "unknown");
 
   py::class_<Logger> logger_holder(m, "logger");
@@ -219,6 +219,6 @@ PYBIND11_MODULE(flexi_cfg, m) {
       .value("WARN", flexi_cfg::logger::Severity::WARN)
       .value("ERROR", flexi_cfg::logger::Severity::ERROR)
       .value("CRITICAL", flexi_cfg::logger::Severity::CRITICAL);
-  logger_holder.def("setLevel", &flexi_cfg::logger::setLevel);
-  logger_holder.def("logLevel", &flexi_cfg::logger::logLevel);
+  logger_holder.def("set_level", &flexi_cfg::logger::setLevel);
+  logger_holder.def("log_level", &flexi_cfg::logger::logLevel);
 }

--- a/python/flexi_cfg_py.cpp
+++ b/python/flexi_cfg_py.cpp
@@ -202,10 +202,9 @@ PYBIND11_MODULE(flexi_cfg, m) {
       .def("getValue", &getValueGeneric);
 
   py::class_<flexi_cfg::Parser>(m, "Parser")
-      .def_static("parse",
-                  py::overload_cast<const std::filesystem::path&>(&flexi_cfg::Parser::parse))
-      .def_static("parse",
-                  py::overload_cast<std::string_view, std::string_view>(&flexi_cfg::Parser::parse),
+      .def_static("parse", &flexi_cfg::Parser::parse, py::arg("cfg_file"), py::arg("root_dir") = std::nullopt)
+      .def_static("parseFromString",
+                  &flexi_cfg::Parser::parseFromString,
                   py::arg("cfg_string"), py::pos_only(), py::arg("source") = "unknown");
 
   m.def("parse", py::overload_cast<const std::filesystem::path&>(&flexi_cfg::parse));

--- a/python/flexi_cfg_py.cpp
+++ b/python/flexi_cfg_py.cpp
@@ -183,7 +183,7 @@ PYBIND11_MODULE(flexi_cfg, m) {
       .def("exists", &flexi_cfg::Reader::exists)
       .def("keys", &flexi_cfg::Reader::keys)
       .def("get_type", &flexi_cfg::Reader::getType)
-      .def("find_struct_with_key", &flexi_cfg::Reader::findStructsWithKey)
+      .def("find_structs_with_key", &flexi_cfg::Reader::findStructsWithKey)
       // Accessors for single values
       .def("get_int", &getValueHelper<int64_t>)
       .def("get_uint64", &getValueHelper<uint64_t>)

--- a/python/test_flexi_cfg.py
+++ b/python/test_flexi_cfg.py
@@ -44,23 +44,23 @@ class TestMyConfig(unittest.TestCase):
                                   'bool_key': False,
                                   'var_ref': 10},
                         'my_list': [1.0, -2, 4.2]}
-        cfg = flexi_cfg.parse(my_config_example, "example_cfg")
-        self.assertEqual(cfg.getString("test1.key1"), expected_cfg["test1"]["key1"])
-        self.assertEqual(cfg.getFloat("test1.key2"), expected_cfg["test1"]["key2"])
-        self.assertEqual(cfg.getInt("test1.key3"), expected_cfg["test1"]["key3"])
-        self.assertEqual(cfg.getUint64("test2.my_hex"), expected_cfg["test2"]["my_hex"])
-        self.assertEqual(cfg.getBool("test2.bool_key"), expected_cfg["test2"]["bool_key"])
-        self.assertEqual(cfg.getFloatList("my_list"), expected_cfg['my_list'])
+        cfg = flexi_cfg.parse_from_string(my_config_example, "example_cfg")
+        self.assertEqual(cfg.get_string("test1.key1"), expected_cfg["test1"]["key1"])
+        self.assertEqual(cfg.get_float("test1.key2"), expected_cfg["test1"]["key2"])
+        self.assertEqual(cfg.get_int("test1.key3"), expected_cfg["test1"]["key3"])
+        self.assertEqual(cfg.get_uint64("test2.my_hex"), expected_cfg["test2"]["my_hex"])
+        self.assertEqual(cfg.get_bool("test2.bool_key"), expected_cfg["test2"]["bool_key"])
+        self.assertEqual(cfg.get_float_list("my_list"), expected_cfg['my_list'])
 
         self.assertEqual(sorted(cfg.keys()), sorted(expected_cfg.keys()))
-        self.assertEqual(cfg.getType("test1.key1"), flexi_cfg.Type.kString)
-        self.assertEqual(cfg.getType("test1.key2"), flexi_cfg.Type.kNumber)
-        self.assertEqual(cfg.getType("test1.key3"), flexi_cfg.Type.kNumber)
-        self.assertEqual(cfg.getType("test2.my_hex"), flexi_cfg.Type.kNumber)
-        self.assertEqual(cfg.getType("test2.bool_key"), flexi_cfg.Type.kBoolean)
-        self.assertEqual(cfg.getType("my_list"), flexi_cfg.Type.kList)
+        self.assertEqual(cfg.get_type("test1.key1"), flexi_cfg.Type.STRING)
+        self.assertEqual(cfg.get_type("test1.key2"), flexi_cfg.Type.NUMBER)
+        self.assertEqual(cfg.get_type("test1.key3"), flexi_cfg.Type.NUMBER)
+        self.assertEqual(cfg.get_type("test2.my_hex"), flexi_cfg.Type.NUMBER)
+        self.assertEqual(cfg.get_type("test2.bool_key"), flexi_cfg.Type.BOOLEAN)
+        self.assertEqual(cfg.get_type("my_list"), flexi_cfg.Type.LIST)
 
-        cfg_test2 = cfg.getReader("test2")
+        cfg_test2 = cfg.get_reader("test2")
         self.assertEqual(sorted(cfg_test2.keys()), sorted(expected_cfg["test2"].keys()))
         
     def test_cfg_file(self):
@@ -88,16 +88,16 @@ class TestMyConfig(unittest.TestCase):
         cfg = flexi_cfg.parse(cfg_file_path)
 
         self.assertEqual(sorted(cfg.keys()), sorted(expected_cfg.keys()))
-        self.assertEqual(cfg.getFloat('test1.key3'), cfg.getFloat('test2.var_ref'))
-        self.assertAlmostEqual(cfg.getFloat('test1.key3'), expected_cfg['test1']['key3'], places=6)
+        self.assertEqual(cfg.get_float('test1.key3'), cfg.get_float('test2.var_ref'))
+        self.assertAlmostEqual(cfg.get_float('test1.key3'), expected_cfg['test1']['key3'], places=6)
 
-        self.assertEqual(cfg.getType('test1.f'), flexi_cfg.Type.kList)
-        self.assertEqual(cfg.getStringList('test1.f'), expected_cfg['test1']['f'])
+        self.assertEqual(cfg.get_type('test1.f'), flexi_cfg.Type.LIST)
+        self.assertEqual(cfg.get_string_list('test1.f'), expected_cfg['test1']['f'])
 
         # Check that parsing a signed integer as an unsigned integer produces an exception.
         excepted = False
         try:
-            cfg.getUint64('uint64')
+            cfg.get_uint64('uint64')
         except flexi_cfg.MismatchTypeException:
             excepted = True
         except:
@@ -105,22 +105,22 @@ class TestMyConfig(unittest.TestCase):
         self.assertTrue(excepted)
 
         # Check various list types:
-        self.assertEqual(cfg.getIntList('int_list'), expected_cfg['int_list'])
-        self.assertEqual(cfg.getUint64List('uint_list'), expected_cfg['uint_list'])
-        self.assertEqual(cfg.getFloatList('float_list'), expected_cfg['float_list'])
+        self.assertEqual(cfg.get_int_list('int_list'), expected_cfg['int_list'])
+        self.assertEqual(cfg.get_uint64_list('uint_list'), expected_cfg['uint_list'])
+        self.assertEqual(cfg.get_float_list('float_list'), expected_cfg['float_list'])
 
-        # Check the generic getValue() method:
-        self.assertEqual(cfg.getValue('test1.key1'), expected_cfg['test1']['key1'])
-        self.assertEqual(cfg.getValue('test1.key2'), expected_cfg['test1']['key2'])
-        self.assertAlmostEqual(cfg.getValue('test1.key3'), expected_cfg['test1']['key3'], places=6)
-        self.assertEqual(cfg.getValue('test2.my_key'), expected_cfg['test2']['my_key'])
-        self.assertEqual(cfg.getValue('test2.n_key'), expected_cfg['test2']['n_key'])
-        self.assertAlmostEqual(cfg.getValue('test2.var_ref'), expected_cfg['test2']['var_ref'], places=6)
-        self.assertEqual(cfg.getValue('solo_key'), expected_cfg['solo_key'])
-        self.assertEqual(cfg.getValue('int_list'), expected_cfg['int_list'])
-        self.assertEqual(cfg.getValue('uint_list'), expected_cfg['uint_list'])
-        self.assertEqual(cfg.getValue('float_list'), expected_cfg['float_list'])
-        self.assertEqual(cfg.getValue('uint64'), expected_cfg['uint64'])
+        # Check the generic get_value() method:
+        self.assertEqual(cfg.get_value('test1.key1'), expected_cfg['test1']['key1'])
+        self.assertEqual(cfg.get_value('test1.key2'), expected_cfg['test1']['key2'])
+        self.assertAlmostEqual(cfg.get_value('test1.key3'), expected_cfg['test1']['key3'], places=6)
+        self.assertEqual(cfg.get_value('test2.my_key'), expected_cfg['test2']['my_key'])
+        self.assertEqual(cfg.get_value('test2.n_key'), expected_cfg['test2']['n_key'])
+        self.assertAlmostEqual(cfg.get_value('test2.var_ref'), expected_cfg['test2']['var_ref'], places=6)
+        self.assertEqual(cfg.get_value('solo_key'), expected_cfg['solo_key'])
+        self.assertEqual(cfg.get_value('int_list'), expected_cfg['int_list'])
+        self.assertEqual(cfg.get_value('uint_list'), expected_cfg['uint_list'])
+        self.assertEqual(cfg.get_value('float_list'), expected_cfg['float_list'])
+        self.assertEqual(cfg.get_value('uint64'), expected_cfg['uint64'])
 
 
 if __name__ == '__main__':

--- a/tests/config_exception_test.cpp
+++ b/tests/config_exception_test.cpp
@@ -91,7 +91,7 @@ TEST(ConfigException, DuplicateKeyException) {
            $BAZ = \"baz\"               \n\
            +bar = 0                     \n\
          }\n";
-    EXPECT_THROW(flexi_cfg::Parser::parse(ref_proto_failure, "ref_proto_failure"),
+    EXPECT_THROW(flexi_cfg::Parser::parseFromString(ref_proto_failure, "ref_proto_failure"),
                  flexi_cfg::config::DuplicateKeyException);
   }
 #if 0  // See FULLPAIR action
@@ -183,7 +183,7 @@ TEST(ConfigException, InvalidKeyException) {
         "struct test1 {         \n\
            key = $(test1.key2)  \n\
          }\n";
-    EXPECT_THROW(flexi_cfg::Parser::parse(invalid_key_reference, "invalid key reference"),
+    EXPECT_THROW(flexi_cfg::Parser::parseFromString(invalid_key_reference, "invalid key reference"),
                  flexi_cfg::config::InvalidKeyException);
   }
   {
@@ -193,7 +193,7 @@ TEST(ConfigException, InvalidKeyException) {
         "struct test1 {             \n\
            key = $(test1.key3.bar)  \n\
          }\n";
-    EXPECT_THROW(flexi_cfg::Parser::parse(not_a_struct, "not a struct"),
+    EXPECT_THROW(flexi_cfg::Parser::parseFromString(not_a_struct, "not a struct"),
                  flexi_cfg::config::InvalidKeyException);
   }
 }
@@ -207,7 +207,7 @@ TEST(ConfigException, InvalidTypeException) {
            key = $(test1.key3.bar)  \n\
            key3 = 0                 \n\
          }\n";
-    EXPECT_THROW(flexi_cfg::Parser::parse(key_wrong_type, "key wrong type"),
+    EXPECT_THROW(flexi_cfg::Parser::parseFromString(key_wrong_type, "key wrong type"),
                  flexi_cfg::config::InvalidTypeException);
   }
   {
@@ -216,8 +216,9 @@ TEST(ConfigException, InvalidTypeException) {
            key1 = \"not a number\"         \n\
            key2 = {{ 0.5 * $(foo.key1) }}  \n\
          }\n";
-    EXPECT_THROW(flexi_cfg::Parser::parse(non_numeric_in_expression, "non numeric in expression"),
-                 flexi_cfg::config::InvalidTypeException);
+    EXPECT_THROW(
+        flexi_cfg::Parser::parseFromString(non_numeric_in_expression, "non numeric in expression"),
+        flexi_cfg::config::InvalidTypeException);
   }
 }
 
@@ -233,7 +234,7 @@ TEST(ConfigException, UndefinedReferenceVarException) {
            $KEY1 = 0                   \n\
            #$KEY2 undefined            \n\
          }\n";
-    EXPECT_THROW(flexi_cfg::Parser::parse(proto_var_doesnt_exist, "$KEY2 is undefined"),
+    EXPECT_THROW(flexi_cfg::Parser::parseFromString(proto_var_doesnt_exist, "$KEY2 is undefined"),
                  flexi_cfg::config::UndefinedReferenceVarException);
   }
   {
@@ -248,7 +249,7 @@ TEST(ConfigException, UndefinedReferenceVarException) {
            $KEY2 = \"defined\"                             \n\
            $EXTRA_KEY = 0  # not useful, but not an error  \n\
          }\n";
-    EXPECT_NO_THROW(flexi_cfg::Parser::parse(extra_proto_var, "$EXTRA_KEY is unused"));
+    EXPECT_NO_THROW(flexi_cfg::Parser::parseFromString(extra_proto_var, "$EXTRA_KEY is unused"));
   }
 
   {
@@ -270,7 +271,7 @@ TEST(ConfigException, UndefinedProtoException) {
            $KEY1 = 0                                       \n\
            $KEY2 = \"defined\"                             \n\
          }\n";
-    EXPECT_THROW(flexi_cfg::Parser::parse(undefined_proto, "bar_proto not defined"),
+    EXPECT_THROW(flexi_cfg::Parser::parseFromString(undefined_proto, "bar_proto not defined"),
                  flexi_cfg::config::UndefinedProtoException);
   }
 }

--- a/tests/config_parse_test.cpp
+++ b/tests/config_parse_test.cpp
@@ -42,7 +42,7 @@ TEST_P(InputString, Reader) {
   flexi_cfg::Reader cfg({}, "");  // Nominally, we wouldn't do this, but we need a mechanism to
                                   // capture the output of 'parse' from within the "try/catch" block
 
-  EXPECT_NO_THROW(cfg = flexi_cfg::Parser::parse(GetParam(), "From String"));
+  EXPECT_NO_THROW(cfg = flexi_cfg::Parser::parseFromString(GetParam(), "From String"));
   EXPECT_TRUE(cfg.exists("test1.key1"));
   EXPECT_EQ(cfg.getValue<std::string>("test1.key1"), "value");
   EXPECT_EQ(cfg.getType("test1.key1"), flexi_cfg::config::types::Type::kString);

--- a/tests/config_parse_test.cpp
+++ b/tests/config_parse_test.cpp
@@ -137,8 +137,21 @@ TEST_P(FileInput, Parse) {
 }
 
 TEST_P(FileInput, ConfigReaderParse) {
+  // This test creates a full path to the config files. This works because they are all top level
   flexi_cfg::logger::setLevel(flexi_cfg::logger::Severity::WARN);
   EXPECT_NO_THROW(flexi_cfg::Parser::parse(baseDir() / GetParam()));
 }
 
+TEST_P(FileInput, ConfigReaderParseRootDir) {
+  // This test calls parse with a relative path to the config file and specifies the root dir
+  flexi_cfg::logger::setLevel(flexi_cfg::logger::Severity::WARN);
+  EXPECT_NO_THROW(flexi_cfg::Parser::parse(GetParam(), baseDir()));
+}
+
 INSTANTIATE_TEST_SUITE_P(ConfigParse, FileInput, testing::ValuesIn(filenameGenerator()));
+
+TEST(ConfigParse, ConfigRoot) {
+  flexi_cfg::logger::setLevel(flexi_cfg::logger::Severity::DEBUG);
+  EXPECT_NO_THROW(flexi_cfg::Parser::parse(
+      std::filesystem::path("config_root/test/config_example_base.cfg"), baseDir()));
+}


### PR DESCRIPTION
*  Previously the root of the config directory was assumed to be the parent directory of the config file.
   This functionality is still supported if the root directory is not specified
*  The user may optionally specify a "root" directory for all config files and a path relative to the base config file