### PR TITLE
Config visitor API with JSON implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,6 +129,9 @@ set(CFG_HEADERS
   include/flexi_cfg/math/actions.h
   include/flexi_cfg/math/grammar.h
   include/flexi_cfg/math/helpers.h
+  include/flexi_cfg/visitor.h
+  include/flexi_cfg/visitor-internal.h
+  include/flexi_cfg/visitor-json.h
   include/flexi_cfg/utils.h)
 
 add_library(flexi_cfg
@@ -161,21 +164,6 @@ install(DIRECTORY "${CMAKE_SOURCE_DIR}/include/"
 
 add_subdirectory(src)
 
-if (CFG_PYTHON_BINDINGS)
-  # Get pybind11
-  FetchContent_Declare(
-    pybind11
-    GIT_REPOSITORY https://github.com/pybind/pybind11.git
-    GIT_TAG        v2.12.0
-    SYSTEM
-    EXCLUDE_FROM_ALL
-  )
-  FetchContent_MakeAvailable(pybind11)
-
-  message(STATUS "Building python bindings")
-  add_subdirectory(python)
-endif()
-
 if (CFG_ENABLE_TEST)
   # Get gtest
   FetchContent_Declare(
@@ -197,4 +185,19 @@ if (CFG_ENABLE_TEST)
 
   enable_testing()
   add_subdirectory(tests)
+endif()
+
+if (CFG_PYTHON_BINDINGS)
+  # Get pybind11
+  FetchContent_Declare(
+          pybind11
+          GIT_REPOSITORY https://github.com/pybind/pybind11.git
+          GIT_TAG        v2.12.0
+          SYSTEM
+          EXCLUDE_FROM_ALL
+  )
+  FetchContent_MakeAvailable(pybind11)
+
+  message(STATUS "Building python bindings")
+  add_subdirectory(python)
 endif()

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # project root will be mounted at /usr/src/flexi_cfg
 COPY <<EOF /usr/bin/cmake-setup
 #!/bin/bash
+pip3 install -r /usr/src/flexi_cfg/requirements.txt
 cmake /usr/src/flexi_cfg -DCMAKE_BUILD_TYPE=Debug -DENABLE_CLANG_TIDY:BOOL=ON -DCFG_ENABLE_DEBUG:BOOL=ON -DCFG_ENABLE_PARSER_TRACE:BOOL=OFF -DCFG_EXAMPLES:BOOL=ON -DCFG_PYTHON_BINDINGS:BOOL=ON -G Ninja
 EOF
 RUN chmod +x /usr/bin/cmake-setup
@@ -65,7 +66,7 @@ term_handler() {
 # Trap termination signals (SIGTERM, SIGINT)
 trap 'term_handler' SIGTERM SIGINT
 
-sudo chown -R ${USER_UID}:${USER_GID} /usr/src/flexi_cfg_build
+sudo chown -R ${USER_UID}:${USER_GID} /usr/src
 echo "== Executing == \$@ =="
 exec "\$@"
 echo "== DONE =="

--- a/README.md
+++ b/README.md
@@ -317,6 +317,58 @@ struct foo {  # A trailing comment works like this
 
 See [`config_example3.cfg`](examples/config_example3.cfg) and [`config_example5.cfg`](examples/config_example5.cfg) for additional examples of comment usage.
 
+## Extras
+
+### JSON Output
+
+When interfacing with other systems and tools that don't support FlexiConfig natively it's often helpful to have a JSON representation of the fully materialized FlexiConfig tree. To export a config to a JSON string, you can use one of the following options:
+
+```cpp
+#include <flexi_cfg/reader.h>
+#include <flexi_cfg/visitor-json.h>
+
+// Parse the config
+auto cfg = flexi_cfg::Parser::parse(std::filesystem::path("config.cfg"));
+
+// Human readable indented JSON format
+auto visitor = flexi_cfg::visitor::PrettyJsonVisitor();
+cfg.visit(visitor);
+std::string json = visitor;
+  
+// Compact JSON format
+auto visitor = flexi_cfg::visitor::JsonVisitor();
+cfg.visit(visitor);
+std::string json = visitor;
+```
+
+```python
+import flexi_cfg
+
+# Parse the config
+cfg = flexi_cfg.parse("config.cfg")
+
+# Human readable indented JSON format
+json = cfg.json(pretty=True)
+
+# Compact JSON format
+json = cfg.json()
+```
+
+### Introspection with Visitor API
+
+The C++ API provides a [visitor pattern](https://en.wikipedia.org/wiki/Visitor_pattern) through `flexi_cfg::Reader.visit(visitor)` to traverse the fully materialized FlexiConfig tree. This API offers a way to examine the configuration structure and data without requiring prior knowledge of specific `keys` or `types` in your code. One example of its utility is the [JSON Output](#JSON Output) functionality; additional formats can be similarly supported with ease.
+
+Implement a visitor `class` that matches one or more of the following [&lt;concepts&gt;](https://en.cppreference.com/w/cpp/language/constraints) and pass it to the `flexi_cfg::Reader` which will then invoke the respective callback functions as it encounters the various FlexiConfig elements the visitor is interested in:
+
+- [flexi_cfg::visitor::KeyVisitor](include/flexi_cfg/visitor.h)
+- [flexi_cfg::visitor::IntValueVisitor](include/flexi_cfg/visitor.h)
+- [flexi_cfg::visitor::FloatValueVisitor](include/flexi_cfg/visitor.h)
+- [flexi_cfg::visitor::StringValueVisitor](include/flexi_cfg/visitor.h)
+- [flexi_cfg::visitor::BoolValueVisitor](include/flexi_cfg/visitor.h)
+- [flexi_cfg::visitor::ListVisitor](include/flexi_cfg/visitor.h)
+- [flexi_cfg::visitor::StructVisitor](include/flexi_cfg/visitor.h)
+
+
 # Parsers
 
 ## C++
@@ -324,7 +376,7 @@ The C++ implementation uses the [`taocpp::pegtl`](https://github.com/taocpp/PEGT
 `PEGTL` uses a templatized syntax to define the grammar (which can be found [here](cpp/config_grammar.h)).  This is used
 for parsing the raw config file, along with a set of [actions](cpp/config_actions.h) which define how to act on the parse
 output.  Once the raw config files are parsed, there is a second pass that does the following:
-1. Finds all protos defined in the parsed output
+1. Finds all protos defined in the parsed output<
 2. Merges all nested structs into a single struct
 3. Resolves all references (and their associated variables), turning references to `proto`s into `struct`s.
 4. Unflattens any flat key/value pairs

--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ The C++ implementation uses the [`taocpp::pegtl`](https://github.com/taocpp/PEGT
 `PEGTL` uses a templatized syntax to define the grammar (which can be found [here](cpp/config_grammar.h)).  This is used
 for parsing the raw config file, along with a set of [actions](cpp/config_actions.h) which define how to act on the parse
 output.  Once the raw config files are parsed, there is a second pass that does the following:
-1. Finds all protos defined in the parsed output<
+1. Finds all protos defined in the parsed output
 2. Merges all nested structs into a single struct
 3. Resolves all references (and their associated variables), turning references to `proto`s into `struct`s.
 4. Unflattens any flat key/value pairs

--- a/examples/config_example16.cfg
+++ b/examples/config_example16.cfg
@@ -1,25 +1,29 @@
+include config_example16_base.cfg
+include config_example16_overlay.cfg
+
 my_value_string = "myvalue"
 my_value_int = 123
 my_value_float = 1.23
-
 my_value_bool = true
-
-struct my_struct {
-    my_value_string = "myvalue"
-    my_value_int = 123
-    my_value_float = 1.23
-}
 
 my_value_list = [ "one", "two", "three" ]
 my_value_uintlist = [0x0, 0x1, 0x3, 0x5]
+my_value_boollist = [true, false, true]
+my_value_list_of_lists = [ [1,2], [2,3], [], [4,5,6] ]
+my_value_empty_list = []
 
-my_value_list_of_lists = [ [1,2], [2,3], [4,5,6] ]
+my_value_list_of_structs = [ $(my_struct), $(constants) ]
 
 proto my_proto {
     struct my_struct_in_proto {
         my_value_string = "myvalue"
         my_value_int = 123
         my_value_float = 1.23
+        my_value_list = [ "one", "two", "three" ]
+        my_value_uintlist = [0x0, 0x1, 0x3, 0x5]
+        my_value_boollist = [true, false, true]
+        my_value_list_of_lists = [ [1,2], [2,3], [4,5,6] ]
+        my_value_empty_list = []
     }
 }
 

--- a/examples/config_example16.cfg
+++ b/examples/config_example16.cfg
@@ -1,0 +1,56 @@
+my_value_string = "myvalue"
+my_value_int = 123
+my_value_float = 1.23
+
+my_value_bool = true
+
+struct my_struct {
+    my_value_string = "myvalue"
+    my_value_int = 123
+    my_value_float = 1.23
+}
+
+my_value_list = [ "one", "two", "three" ]
+my_value_uintlist = [0x0, 0x1, 0x3, 0x5]
+
+my_value_list_of_lists = [ [1,2], [2,3], [4,5,6] ]
+
+proto my_proto {
+    struct my_struct_in_proto {
+        my_value_string = "myvalue"
+        my_value_int = 123
+        my_value_float = 1.23
+    }
+}
+
+reference my_proto as my_proto_as_struct { }
+
+struct constants {
+  var1 = 0.15
+  var2 = -0.06
+  var3 = 9.0
+}
+
+proto test_proto {
+  struct left {
+    name = $PARENT
+    offset = [$(constants.var1), $INSIDE, $(constants.var2), -0.5]
+  }
+  struct right {
+    name = $PARENT
+    offset = [$(constants.var1), $OUTSIDE, $(constants.var2)]
+  }
+}
+
+reference test_proto as front {
+  $PARENT = $PARENT_NAME
+  $INSIDE = $(constants.var3)
+  $OUTSIDE = {{ -$(constants.var3) }}
+}
+
+reference test_proto as back {
+  $PARENT = $PARENT_NAME
+  $INSIDE = {{ -1 * $(constants.var3) }}
+  $OUTSIDE = $(constants.var3)
+  +test_list = [0.123, $(constants.var2), 4.567]
+}

--- a/examples/config_example16_base.cfg
+++ b/examples/config_example16_base.cfg
@@ -1,0 +1,6 @@
+struct my_struct {
+    my_value_string = "myvalue"
+    my_value_int = 123
+    my_value_float = 1.23
+    my_value_bool = true
+}

--- a/examples/config_example16_overlay.cfg
+++ b/examples/config_example16_overlay.cfg
@@ -1,0 +1,12 @@
+# struct overrides
+my_struct.my_value_string [override] = "myvalue-override"
+my_struct.my_value_int [override] = 1234
+my_struct.my_value_float [override] = 1.234
+my_struct.my_value_bool [override] = false
+
+# struct extra fields
+my_struct.my_value_list = [ "one", "two", "three" ]
+my_struct.my_value_uintlist = [0x0, 0x1, 0x3, 0x5]
+my_struct.my_value_boollist = [true, false, true]
+my_struct.my_value_list_of_lists = [ [1,2], [2,3], [4,5,6] ]
+my_struct.my_value_empty_list = []

--- a/include/flexi_cfg/reader.h
+++ b/include/flexi_cfg/reader.h
@@ -3,19 +3,21 @@
 #include <fmt/format.h>
 
 #include <array>
-#include <filesystem>
-#include <iostream>
 #include <memory>
+#include <range/v3/range/conversion.hpp>
 #include <string>
 #include <string_view>
+#include <variant>
 #include <vector>
 
-#include "flexi_cfg/config/actions.h"
 #include "flexi_cfg/config/classes.h"
 #include "flexi_cfg/config/exceptions.h"
 #include "flexi_cfg/config/helpers.h"
 #include "flexi_cfg/logger.h"
 #include "flexi_cfg/utils.h"
+#include "flexi_cfg/visitor.h"
+#include "flexi_cfg/visitor-internal.h"
+#include "flexi_cfg/reader.h"
 
 namespace flexi_cfg {
 
@@ -32,6 +34,15 @@ class Reader {
 
   /// \brief Prints the full config to the console
   void dump() const;
+
+  /// \brief Prints the full config to the stream
+  void dump(std::ostream& os) const;
+
+  /// \brief Walks the full config tree
+  template <visitor::TypedVisitor Visitor>
+  void visit(Visitor& visitor) const {
+    return visitor::internal::visitStruct(cfg_data_, visitor);
+  }
 
   /// \brief Checks if an entry with the provided key exists
   /// \param[in] key The name of the key of interest

--- a/include/flexi_cfg/reader.h
+++ b/include/flexi_cfg/reader.h
@@ -3,11 +3,9 @@
 #include <fmt/format.h>
 
 #include <array>
+#include <iostream>
 #include <memory>
-#include <range/v3/range/conversion.hpp>
 #include <string>
-#include <string_view>
-#include <variant>
 #include <vector>
 
 #include "flexi_cfg/config/classes.h"
@@ -15,9 +13,8 @@
 #include "flexi_cfg/config/helpers.h"
 #include "flexi_cfg/logger.h"
 #include "flexi_cfg/utils.h"
-#include "flexi_cfg/visitor.h"
 #include "flexi_cfg/visitor-internal.h"
-#include "flexi_cfg/reader.h"
+#include "flexi_cfg/visitor.h"
 
 namespace flexi_cfg {
 

--- a/include/flexi_cfg/visitor-internal.h
+++ b/include/flexi_cfg/visitor-internal.h
@@ -1,0 +1,170 @@
+#pragma once
+
+#include <fmt/format.h>
+
+#include <memory>
+#include <range/v3/range/conversion.hpp>
+#include <range/v3/view.hpp>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "flexi_cfg/config/classes.h"
+#include "flexi_cfg/logger.h"
+#include "flexi_cfg/utils.h"
+#include "flexi_cfg/visitor.h"
+
+namespace flexi_cfg::visitor::internal {
+
+template <typename T>
+bool tryCast(const std::any& any_val, T& value) {
+  try {
+    value = std::any_cast<T>(any_val);
+    return true;
+  } catch (std::bad_any_cast&) {
+    return false;
+  }
+}
+
+template <TypedVisitor Visitor>
+void visitStruct(const config::types::CfgMap& cfg, Visitor& visitor);
+
+template <TypedVisitor Visitor>
+void visitValue(const std::string& key, std::shared_ptr<config::types::ConfigBase> cfg_val,
+                Visitor& visitor) {
+  switch (cfg_val->type) {
+    case config::types::Type::kString: {
+      if constexpr (visitor::StringValueVisitor<Visitor>) {
+        auto config = std::dynamic_pointer_cast<config::types::ConfigValue>(cfg_val);
+        if (config != nullptr) {
+          auto value = config->value;
+          // matches Reader::convert(..)
+          value.erase(std::remove(std::begin(value), std::end(value), '\"'), std::end(value));
+          visitor.onValue(value);
+          break;
+        }
+      }
+    }
+
+    case config::types::Type::kNumber: {
+      auto config = std::dynamic_pointer_cast<config::types::ConfigValue>(cfg_val);
+      if (config != nullptr) {
+        if constexpr (visitor::IntValueVisitor<Visitor>) {
+          if (int8_t i_val; tryCast(config->value_any, i_val)) {
+            visitor.onValue(static_cast<int64_t>(i_val));
+            break;
+          }
+          if (uint8_t ui_val; tryCast(config->value_any, ui_val)) {
+            visitor.onValue(static_cast<uint64_t>(ui_val));
+            break;
+          }
+          if (int16_t i_val; tryCast(config->value_any, i_val)) {
+            visitor.onValue(static_cast<int64_t>(i_val));
+            break;
+          }
+          if (uint16_t ui_val; tryCast(config->value_any, ui_val)) {
+            visitor.onValue(static_cast<uint64_t>(ui_val));
+            break;
+          }
+          if (int32_t i_val; tryCast(config->value_any, i_val)) {
+            visitor.onValue(static_cast<int64_t>(i_val));
+            break;
+          }
+          if (uint32_t ui_val; tryCast(config->value_any, ui_val)) {
+            visitor.onValue(static_cast<uint64_t>(ui_val));
+            break;
+          }
+          if (int64_t i_val; tryCast(config->value_any, i_val)) {
+            visitor.onValue(i_val);
+            break;
+          }
+          if (uint64_t ui_val; tryCast(config->value_any, ui_val)) {
+            visitor.onValue(ui_val);
+            break;
+          }
+          if (long long i_val; tryCast(config->value_any, i_val)) {
+            visitor.onValue(static_cast<int64_t>(i_val));
+            break;
+          }
+          if (unsigned long long ui_val; tryCast(config->value_any, ui_val)) {
+            visitor.onValue(static_cast<uint64_t>(ui_val));
+            break;
+          }
+        }
+        if constexpr (visitor::FloatValueVisitor<Visitor>) {
+          if (float f_val; tryCast(config->value_any, f_val)) {
+            visitor.onValue(f_val);
+            break;
+          }
+          if (double d_val; tryCast(config->value_any, d_val)) {
+            visitor.onValue(d_val);
+            break;
+          }
+          if (long double d_val; tryCast(config->value_any, d_val)) {
+            visitor.onValue(static_cast<double>(d_val));
+            break;
+          }
+        }
+      }
+    }
+
+    case config::types::Type::kBoolean: {
+      if constexpr (visitor::BoolValueVisitor<Visitor>) {
+        auto config = std::dynamic_pointer_cast<config::types::ConfigValue>(cfg_val);
+        if (bool b_val; config != nullptr && tryCast(config->value_any, b_val)) {
+          visitor.onValue(b_val);
+          break;
+        }
+      }
+    }
+
+    case config::types::Type::kStruct:
+    case config::types::Type::kStructInProto: {
+      if constexpr (visitor::StructVisitor<Visitor>) {
+        auto config = std::dynamic_pointer_cast<config::types::ConfigStructLike>(cfg_val);
+        if (config != nullptr) {
+          visitStruct(config->data, visitor);
+          break;
+        }
+      }
+    }
+
+    case config::types::Type::kList: {
+      if constexpr (visitor::ListVisitor<Visitor>) {
+        auto config = std::dynamic_pointer_cast<config::types::ConfigList>(cfg_val);
+        if (config != nullptr) {
+          visitor.beginList();
+          for (auto list_cfg_val : config->data) {
+            visitValue(key, list_cfg_val, visitor);
+          }
+          visitor.endList();
+          break;
+        }
+      }
+    }
+
+    default:
+      logger::warn("Visitor, unhandled key: {} -- Type: {} ", key,
+                   magic_enum::enum_name(cfg_val->type));
+      break;
+  }
+}
+
+template <TypedVisitor Visitor>
+void visitStruct(const config::types::CfgMap& cfg, Visitor& visitor) {
+  if constexpr (visitor::StructVisitor<Visitor>) {
+    visitor.beginStruct();
+  }
+  for (const auto& key : cfg | ranges::views::keys | ranges::to<std::vector<std::string>>) {
+    auto cfg_val = cfg.at(key);
+    if constexpr (visitor::KeyVisitor<Visitor>) {
+      visitor.onKey(key);
+    }
+    visitValue(key, cfg_val, visitor);
+  }
+  if constexpr (visitor::StructVisitor<Visitor>) {
+    visitor.endStruct();
+  }
+}
+
+}  // namespace flexi_cfg::visitor::internal

--- a/include/flexi_cfg/visitor-json.h
+++ b/include/flexi_cfg/visitor-json.h
@@ -1,0 +1,109 @@
+#pragma once
+
+#include <fmt/format.h>
+
+#include <string>
+
+#include "flexi_cfg/visitor.h"
+
+namespace flexi_cfg::visitor {
+
+class JsonVisitor {
+ public:
+  operator std::string() { return json_; }
+  void onKey(std::string key) { json_ += fmt::format("\"{}\":", key); }
+  void onValue(std::string value) { json_ += fmt::format("\"{}\",", value); }
+  void onValue(int64_t value) { json_ += fmt::format("{},", value); }
+  void onValue(uint64_t value) { json_ += fmt::format("{},", value); }
+  void onValue(double value) { json_ += fmt::format("{},", value); }
+  void onValue(bool value) { json_ += fmt::format("{},", value); }
+  void beginStruct() {
+    json_ += "{";
+    struct_count_++;
+  }
+  void endStruct() {
+    struct_count_--;
+    json_.resize(json_.length() - 1);  // strip last ','
+    json_ += "}";
+    if (struct_count_ > 0) {
+      json_ += ",";
+    }
+  }
+  void beginList() { json_ += "["; }
+  void endList() {
+    json_.resize(json_.length() - 1);  // strip last ','
+    json_ += "],";
+  }
+
+ private:
+  std::string json_;
+  unsigned int struct_count_{};
+};
+
+static_assert(StructVisitor<JsonVisitor>);
+static_assert(ListVisitor<JsonVisitor>);
+static_assert(StringValueVisitor<JsonVisitor>);
+static_assert(BoolValueVisitor<JsonVisitor>);
+static_assert(IntValueVisitor<JsonVisitor>);
+static_assert(FloatValueVisitor<JsonVisitor>);
+
+class PrettyJsonVisitor {
+ public:
+  operator std::string() { return json_; }
+  void onKey(std::string key) {
+    updateIndent();
+    json_ += fmt::format("{}\"{}\" :", indent_, key);
+    indent_ = " ";  // inline value
+  }
+  void onValue(std::string value) { json_ += fmt::format("{}\"{}\",\n", indent_, value); }
+  void onValue(int64_t value) { json_ += fmt::format("{}{},\n", indent_, value); }
+  void onValue(uint64_t value) { json_ += fmt::format("{}{},\n", indent_, value); }
+  void onValue(double value) { json_ += fmt::format("{}{},\n", indent_, value); }
+  void onValue(bool value) { json_ += fmt::format("{}{},\n", indent_, value); }
+  void beginStruct() {
+    json_ += fmt::format("{}{{\n", indent_);  // open inline
+    nest_count_++;
+    updateIndent();
+  }
+  void endStruct() {
+    stripComma();
+    nest_count_--;
+    updateIndent();
+    json_ += fmt::format("{}}}", indent_);  // close at parent indent
+    if (nest_count_ > 0) {
+      json_ += ",\n";
+    } else {
+      json_ += "\n";
+    }
+  }
+  void beginList() {
+    json_ += fmt::format("{}[\n", indent_);  // open inline
+    nest_count_++;
+    updateIndent();
+  }
+  void endList() {
+    stripComma();
+    nest_count_--;
+    updateIndent();
+    json_ += fmt::format("{}],\n", indent_);  // close at parent indent
+  }
+
+ private:
+  void updateIndent() { indent_ = std::string(nest_count_ * 2, ' '); }
+  void stripComma() {
+    json_.resize(json_.length() - 2);  // strip last ',\n'
+    json_ += "\n";                     // replace with '\n'
+  }
+  std::string indent_{};
+  std::string json_;
+  unsigned int nest_count_{};
+};
+
+static_assert(StructVisitor<PrettyJsonVisitor>);
+static_assert(ListVisitor<PrettyJsonVisitor>);
+static_assert(StringValueVisitor<PrettyJsonVisitor>);
+static_assert(BoolValueVisitor<PrettyJsonVisitor>);
+static_assert(IntValueVisitor<PrettyJsonVisitor>);
+static_assert(FloatValueVisitor<PrettyJsonVisitor>);
+
+}  // namespace flexi_cfg::visitor

--- a/include/flexi_cfg/visitor-json.h
+++ b/include/flexi_cfg/visitor-json.h
@@ -22,8 +22,8 @@ class JsonVisitor {
     struct_count_++;
   }
   void endStruct() {
+    stripComma();
     struct_count_--;
-    json_.resize(json_.length() - 1);  // strip last ','
     json_ += "}";
     if (struct_count_ > 0) {
       json_ += ",";
@@ -31,11 +31,16 @@ class JsonVisitor {
   }
   void beginList() { json_ += "["; }
   void endList() {
-    json_.resize(json_.length() - 1);  // strip last ','
+    stripComma();
     json_ += "],";
   }
 
  private:
+  void stripComma() {
+    if (json_.back() == ',') {
+      json_.pop_back();  // strip last ','
+    }
+  }
   std::string json_;
   unsigned int struct_count_{};
 };
@@ -91,8 +96,11 @@ class PrettyJsonVisitor {
  private:
   void updateIndent() { indent_ = std::string(nest_count_ * 2, ' '); }
   void stripComma() {
-    json_.resize(json_.length() - 2);  // strip last ',\n'
-    json_ += "\n";                     // replace with '\n'
+    if (json_.ends_with(",\n")) {  // replace ',\n' with '\n'
+      json_.pop_back();
+      json_.pop_back();
+      json_.push_back('\n');
+    }
   }
   std::string indent_{};
   std::string json_;

--- a/include/flexi_cfg/visitor.h
+++ b/include/flexi_cfg/visitor.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <string>
+
+namespace flexi_cfg::visitor {
+
+template <typename Visitor>
+concept KeyVisitor = requires(Visitor& visitor, std::string key) { visitor.onKey(key); };
+
+template <typename Visitor>
+concept BoolValueVisitor = KeyVisitor<Visitor> && requires(Visitor& visitor, bool value) {
+  { visitor.onValue(value) };
+};
+
+template <typename Visitor>
+concept IntValueVisitor =
+    KeyVisitor<Visitor> && requires(Visitor& visitor, int64_t value, uint64_t unsigned_value) {
+      { visitor.onValue(value) };
+      { visitor.onValue(unsigned_value) };
+    };
+
+template <typename Visitor>
+concept FloatValueVisitor = KeyVisitor<Visitor> && requires(Visitor& visitor, double value) {
+  { visitor.onValue(value) };
+};
+
+template <typename Visitor>
+concept StringValueVisitor = KeyVisitor<Visitor> && requires(Visitor& visitor, std::string value) {
+  { visitor.onValue(value) };
+};
+
+template <typename Visitor>
+concept ListVisitor = requires(Visitor& visitor) {
+  { visitor.beginList() };
+  { visitor.endList() };
+};
+
+template <typename Visitor>
+concept StructVisitor = KeyVisitor<Visitor> && requires(Visitor& visitor) {
+  { visitor.beginStruct() };
+  { visitor.endStruct() };
+};
+
+template <typename Visitor>
+concept TypedVisitor = KeyVisitor<Visitor> || IntValueVisitor<Visitor> ||
+                       FloatValueVisitor<Visitor> || StringValueVisitor<Visitor> ||
+                       BoolValueVisitor<Visitor> || ListVisitor<Visitor> || StructVisitor<Visitor>;
+
+}  // namespace flexi_cfg::visitor

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,6 +1,7 @@
 
 find_package(Python COMPONENTS Interpreter Development)
 find_package(pybind11 CONFIG)
+find_package(Pytest 8.3 REQUIRED)
 
 # message(STATUS "site-packages (arch):  ${Python_SITEARCH}")
 # message(STATUS "site-packages (lib):   ${Python_SITELIB}")
@@ -15,14 +16,6 @@ pybind11_add_module(flexi_cfg_py flexi_cfg_py.cpp)
 target_link_libraries(flexi_cfg_py PUBLIC flexi_cfg)
 set_target_properties(flexi_cfg_py PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
 set_target_properties(flexi_cfg_py PROPERTIES OUTPUT_NAME ${PROJECT_NAME})
-
-add_test(NAME test_flexi_cfg
-  COMMAND ${Python_EXECUTABLE} -m pytest ${CMAKE_CURRENT_SOURCE_DIR}
-  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-  )
-set_tests_properties(test_flexi_cfg
-  PROPERTIES ENVIRONMENT "EXAMPLES_DIR=${PROJECT_SRC_DIR}/examples")
-
 
 # detect virtualenv and set Pip args accordingly
 if(DEFINED ENV{VIRTUAL_ENV} OR DEFINED ENV{CONDA_PREFIX})
@@ -47,6 +40,18 @@ if (NOT(${CMAKE_SYSTEM_NAME} MATCHES "Darwin"))
   add_custom_target(flexi_cfg_py_stubgen ALL DEPENDS ${PROJECT_NAME}/__init__.pyi)
 endif()
 
+if (CFG_ENABLE_TEST)
+pytest_discover_tests(
+        test_flexi_cfg_py
+        LIBRARY_PATH_PREPEND
+        $<TARGET_FILE_DIR:flexi_cfg_py>
+        PYTHON_PATH_PREPEND
+        $<TARGET_FILE_DIR:flexi_cfg_py>
+#        TRIM_FROM_NAME "^test_"
+        ENVIRONMENT  "EXAMPLES_DIR=${CMAKE_SOURCE_DIR}/examples"
+        DEPENDS flexi_cfg_py
+)
+endif()
 
 install(TARGETS flexi_cfg_py
         COMPONENT python

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -47,7 +47,6 @@ pytest_discover_tests(
         $<TARGET_FILE_DIR:flexi_cfg_py>
         PYTHON_PATH_PREPEND
         $<TARGET_FILE_DIR:flexi_cfg_py>
-#        TRIM_FROM_NAME "^test_"
         ENVIRONMENT  "EXAMPLES_DIR=${CMAKE_SOURCE_DIR}/examples"
         DEPENDS flexi_cfg_py
 )

--- a/python/flexi_cfg_py.cpp
+++ b/python/flexi_cfg_py.cpp
@@ -192,7 +192,7 @@ PYBIND11_MODULE(flexi_cfg, m) {
             r.visit(json_visitor);
             return json_visitor;
           },
-          py::arg("pretty")=true)
+          py::arg("pretty")=false)
       .def("dump", [](const flexi_cfg::Reader& r) { r.dump(); })
       .def("exists", &flexi_cfg::Reader::exists)
       .def("keys", &flexi_cfg::Reader::keys)

--- a/python/flexi_cfg_py.cpp
+++ b/python/flexi_cfg_py.cpp
@@ -4,6 +4,7 @@
 #include <flexi_cfg/parser.h>
 #include <flexi_cfg/reader.h>
 #include <flexi_cfg/utils.h>
+#include <flexi_cfg/visitor-json.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 #include <pybind11/stl/filesystem.h>
@@ -179,7 +180,20 @@ PYBIND11_MODULE(flexi_cfg, m) {
                                                                       pyFlexiCfgException);
 
   py::class_<flexi_cfg::Reader>(m, "Reader")
-      .def("dump", &flexi_cfg::Reader::dump)
+      .def(
+          "json",
+          [](const flexi_cfg::Reader& r, bool pretty) -> std::string {
+            if (pretty) {
+              auto json_visitor = flexi_cfg::visitor::PrettyJsonVisitor();
+              r.visit(json_visitor);
+              return json_visitor;
+            }
+            auto json_visitor = flexi_cfg::visitor::JsonVisitor();
+            r.visit(json_visitor);
+            return json_visitor;
+          },
+          py::arg("pretty")=true)
+      .def("dump", [](const flexi_cfg::Reader& r) { r.dump(); })
       .def("exists", &flexi_cfg::Reader::exists)
       .def("keys", &flexi_cfg::Reader::keys)
       .def("get_type", &flexi_cfg::Reader::getType)
@@ -202,14 +216,14 @@ PYBIND11_MODULE(flexi_cfg, m) {
       .def("get_value", &getValueGeneric);
 
   py::class_<flexi_cfg::Parser>(m, "Parser")
-      .def_static("parse", &flexi_cfg::Parser::parse, py::arg("cfg_file"), py::arg("root_dir") = std::nullopt)
-      .def_static("parse_from_string",
-                  &flexi_cfg::Parser::parseFromString,
-                  py::arg("cfg_string"), py::pos_only(), py::arg("source") = "unknown");
+      .def_static("parse", &flexi_cfg::Parser::parse, py::arg("cfg_file"),
+                  py::arg("root_dir") = std::nullopt)
+      .def_static("parse_from_string", &flexi_cfg::Parser::parseFromString, py::arg("cfg_string"),
+                  py::pos_only(), py::arg("source") = "unknown");
 
   m.def("parse", &flexi_cfg::parse, py::arg("cfg_file"), py::arg("root_dir") = std::nullopt);
-  m.def("parse_from_string", &flexi_cfg::parseFromString,
-        py::arg("cfg_string"), py::pos_only(), py::arg("source") = "unknown");
+  m.def("parse_from_string", &flexi_cfg::parseFromString, py::arg("cfg_string"), py::pos_only(),
+        py::arg("source") = "unknown");
 
   py::class_<Logger> logger_holder(m, "logger");
   py::enum_<flexi_cfg::logger::Severity>(logger_holder, "Severity")

--- a/python/test_flexi_cfg.py
+++ b/python/test_flexi_cfg.py
@@ -1,7 +1,5 @@
-import logging
 import math
 import os
-import pprint
 import unittest
 import json
 

--- a/python/test_flexi_cfg.py
+++ b/python/test_flexi_cfg.py
@@ -3,6 +3,7 @@ import math
 import os
 import pprint
 import unittest
+import json
 
 import flexi_cfg
 
@@ -62,14 +63,16 @@ class TestMyConfig(unittest.TestCase):
 
         cfg_test2 = cfg.get_reader("test2")
         self.assertEqual(sorted(cfg_test2.keys()), sorted(expected_cfg["test2"].keys()))
-        
-    def test_cfg_file(self):
+
+    def parse_cfg_file(self):
         cfg_file = "config_example1.cfg"
         try:
             cfg_file_path = os.path.join(os.environ['EXAMPLES_DIR'], cfg_file)
         except KeyError:
             cfg_file_path = os.path.join("../examples", cfg_file)
+        return flexi_cfg.parse(cfg_file_path)
 
+    def expected_cfg_file(self):
         expected_cfg = {'another_key': "test",
                         'test1': {'f': ['foo', 'bar', 'baz'],
                                   'key1': 'value',
@@ -89,8 +92,11 @@ class TestMyConfig(unittest.TestCase):
                         'c' : 2,
                         'd' : 2,}
         expected_cfg['test2']['var_ref'] = expected_cfg['test1']['key3']
-        
-        cfg = flexi_cfg.parse(cfg_file_path)
+        return expected_cfg;
+
+    def test_cfg_file(self):
+        cfg = self.parse_cfg_file()
+        expected_cfg = self.expected_cfg_file()
 
         self.assertEqual(sorted(cfg.keys()), sorted(expected_cfg.keys()))
         self.assertEqual(cfg.get_float('test1.key3'), cfg.get_float('test2.var_ref'))
@@ -127,6 +133,20 @@ class TestMyConfig(unittest.TestCase):
         self.assertEqual(cfg.get_value('float_list'), expected_cfg['float_list'])
         self.assertEqual(cfg.get_value('uint64'), expected_cfg['uint64'])
 
+    def validate_cfg_file(self, cfg):
+        expected_cfg = self.expected_cfg_file()
+        # deep equals check on config dicts
+        self.assertEqual(cfg, expected_cfg, "JSON parsed config should match the Python dict")
+
+    def test_cfg_file_as_json(self):
+        cfg_reader = self.parse_cfg_file()
+        cfg = json.loads(cfg_reader.json())
+        self.validate_cfg_file(cfg)
+
+    def test_cfg_file_as_json(self):
+        cfg_reader = self.parse_cfg_file()
+        cfg = json.loads(cfg_reader.json(pretty=False))
+        self.validate_cfg_file(cfg)
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-pe
-deepdiff
-pytest
+pe==0.5
+deepdiff==8.0
+pytest==8.3
+pytest-cmake==0.11

--- a/src/config_reader.cpp
+++ b/src/config_reader.cpp
@@ -60,7 +60,9 @@ namespace flexi_cfg {
 Reader::Reader(config::types::CfgMap cfg, std::string parent)
     : cfg_data_(std::move(cfg)), parent_name_(std::move(parent)) {}
 
-void Reader::dump() const { std::cout << cfg_data_; }
+void Reader::dump() const { dump(std::cout); }
+
+void Reader::dump(std::ostream& os) const { os << cfg_data_; }
 
 auto Reader::exists(const std::string& key) const -> bool {
   try {

--- a/tests/config_parse_test.cpp
+++ b/tests/config_parse_test.cpp
@@ -15,6 +15,8 @@
 #include "flexi_cfg/logger.h"
 #include "flexi_cfg/parser.h"
 #include "flexi_cfg/reader.h"
+#include "flexi_cfg/visitor-json.h"
+#include "flexi_cfg/visitor.h"
 
 namespace peg = TAO_PEGTL_NAMESPACE;
 
@@ -282,4 +284,130 @@ TEST(ConfigParse, ConfigRoot) {
   setLevel(flexi_cfg::logger::Severity::DEBUG);
   EXPECT_NO_THROW(flexi_cfg::Parser::parse(
       std::filesystem::path("config_root/test/config_example_base.cfg"), baseDir()));
+}
+
+TEST(ConfigVisitor, JsonConfigVisitor) {
+  setLevel(flexi_cfg::logger::Severity::INFO);
+  auto cfg = flexi_cfg::Parser::parse(std::filesystem::path("config_example16.cfg"), baseDir());
+
+  auto visitor = flexi_cfg::visitor::JsonVisitor();
+  cfg.visit(visitor);
+  std::string json = visitor;
+
+  ASSERT_EQ(
+      "{\"back\":{\"left\":{\"name\":\"back\",\"offset\":[0.15,-9,-0.06,-0.5]},\"right\":{\"name\":"
+      "\"back\",\"offset\":[0.15,9,-0.06]},\"test_list\":[0.123,-0.06,4.567]},\"constants\":{"
+      "\"var1\":0.15,\"var2\":-0.06,\"var3\":9},\"front\":{\"left\":{\"name\":\"front\",\"offset\":"
+      "[0.15,9,-0.06,-0.5]},\"right\":{\"name\":\"front\",\"offset\":[0.15,-9,-0.06]}},\"my_proto_"
+      "as_struct\":{\"my_struct_in_proto\":{\"my_value_float\":1.23,\"my_value_int\":123,\"my_"
+      "value_string\":\"myvalue\"}},\"my_struct\":{\"my_value_float\":1.23,\"my_value_int\":123,"
+      "\"my_value_string\":\"myvalue\"},\"my_value_bool\":true,\"my_value_float\":1.23,\"my_value_"
+      "int\":123,\"my_value_list\":[\"one\",\"two\",\"three\"],\"my_value_list_of_lists\":[[1,2],["
+      "2,3],[4,5,6]],\"my_value_string\":\"myvalue\",\"my_value_uintlist\":[0,1,3,5]}",
+      json);
+}
+
+TEST(ConfigVisitor, PrettyJsonConfigVisitor) {
+  setLevel(flexi_cfg::logger::Severity::INFO);
+  auto cfg = flexi_cfg::Parser::parse(std::filesystem::path("config_example16.cfg"), baseDir());
+
+  auto visitor = flexi_cfg::visitor::PrettyJsonVisitor();
+  cfg.visit(visitor);
+  std::string json = visitor;
+
+  ASSERT_EQ(
+      R"({
+  "back" : {
+    "left" : {
+      "name" : "back",
+      "offset" : [
+        0.15,
+        -9,
+        -0.06,
+        -0.5
+      ]
+    },
+    "right" : {
+      "name" : "back",
+      "offset" : [
+        0.15,
+        9,
+        -0.06
+      ]
+    },
+    "test_list" : [
+      0.123,
+      -0.06,
+      4.567
+    ]
+  },
+  "constants" : {
+    "var1" : 0.15,
+    "var2" : -0.06,
+    "var3" : 9
+  },
+  "front" : {
+    "left" : {
+      "name" : "front",
+      "offset" : [
+        0.15,
+        9,
+        -0.06,
+        -0.5
+      ]
+    },
+    "right" : {
+      "name" : "front",
+      "offset" : [
+        0.15,
+        -9,
+        -0.06
+      ]
+    }
+  },
+  "my_proto_as_struct" : {
+    "my_struct_in_proto" : {
+      "my_value_float" : 1.23,
+      "my_value_int" : 123,
+      "my_value_string" : "myvalue"
+    }
+  },
+  "my_struct" : {
+    "my_value_float" : 1.23,
+    "my_value_int" : 123,
+    "my_value_string" : "myvalue"
+  },
+  "my_value_bool" : true,
+  "my_value_float" : 1.23,
+  "my_value_int" : 123,
+  "my_value_list" : [
+    "one",
+    "two",
+    "three"
+  ],
+  "my_value_list_of_lists" : [
+    [
+      1,
+      2
+    ],
+    [
+      2,
+      3
+    ],
+    [
+      4,
+      5,
+      6
+    ]
+  ],
+  "my_value_string" : "myvalue",
+  "my_value_uintlist" : [
+    0,
+    1,
+    3,
+    5
+  ]
+}
+)",
+      json);
 }

--- a/tests/config_parse_test.cpp
+++ b/tests/config_parse_test.cpp
@@ -2,7 +2,7 @@
 
 #include <atomic>
 #include <filesystem>
-#include <latch>
+#include <regex>
 #include <string>
 #include <tao/pegtl.hpp>
 #include <tao/pegtl/contrib/parse_tree.hpp>
@@ -16,7 +16,6 @@
 #include "flexi_cfg/parser.h"
 #include "flexi_cfg/reader.h"
 #include "flexi_cfg/visitor-json.h"
-#include "flexi_cfg/visitor.h"
 
 namespace peg = TAO_PEGTL_NAMESPACE;
 
@@ -231,11 +230,12 @@ auto baseDir() -> const std::filesystem::path& {
 }
 
 auto filenameGenerator() -> std::vector<std::filesystem::path> {
+  // don't try to parse files meant to be included
+  std::regex re_config(R"(config_example_\d+\.cfg)");
   std::vector<std::filesystem::path> files;
   for (const auto& entry : std::filesystem::directory_iterator(baseDir())) {
     if (entry.is_regular_file()) {
-      if (const auto& file = entry.path().filename().string();
-          file.starts_with("config_example") && file.ends_with(".cfg")) {
+      if (const auto& file = entry.path().filename().string(); std::regex_match(file, re_config)) {
         files.emplace_back(file);
       }
     }

--- a/tests/config_parse_test.cpp
+++ b/tests/config_parse_test.cpp
@@ -299,11 +299,21 @@ TEST(ConfigVisitor, JsonConfigVisitor) {
       "\"back\",\"offset\":[0.15,9,-0.06]},\"test_list\":[0.123,-0.06,4.567]},\"constants\":{"
       "\"var1\":0.15,\"var2\":-0.06,\"var3\":9},\"front\":{\"left\":{\"name\":\"front\",\"offset\":"
       "[0.15,9,-0.06,-0.5]},\"right\":{\"name\":\"front\",\"offset\":[0.15,-9,-0.06]}},\"my_proto_"
-      "as_struct\":{\"my_struct_in_proto\":{\"my_value_float\":1.23,\"my_value_int\":123,\"my_"
-      "value_string\":\"myvalue\"}},\"my_struct\":{\"my_value_float\":1.23,\"my_value_int\":123,"
-      "\"my_value_string\":\"myvalue\"},\"my_value_bool\":true,\"my_value_float\":1.23,\"my_value_"
-      "int\":123,\"my_value_list\":[\"one\",\"two\",\"three\"],\"my_value_list_of_lists\":[[1,2],["
-      "2,3],[4,5,6]],\"my_value_string\":\"myvalue\",\"my_value_uintlist\":[0,1,3,5]}",
+      "as_struct\":{\"my_struct_in_proto\":{\"my_value_boollist\":[true,false,true],\"my_value_"
+      "empty_list\":[],\"my_value_float\":1.23,\"my_value_int\":123,\"my_value_list\":[\"one\","
+      "\"two\",\"three\"],\"my_value_list_of_lists\":[[1,2],[2,3],[4,5,6]],\"my_value_string\":"
+      "\"myvalue\",\"my_value_uintlist\":[0,1,3,5]}},\"my_struct\":{\"my_value_bool\":false,\"my_"
+      "value_boollist\":[true,false,true],\"my_value_empty_list\":[],\"my_value_float\":1.234,\"my_"
+      "value_int\":1234,\"my_value_list\":[\"one\",\"two\",\"three\"],\"my_value_list_of_lists\":[["
+      "1,2],[2,3],[4,5,6]],\"my_value_string\":\"myvalue-override\",\"my_value_uintlist\":[0,1,3,5]"
+      "},\"my_value_bool\":true,\"my_value_boollist\":[true,false,true],\"my_value_empty_list\":[],"
+      "\"my_value_float\":1.23,\"my_value_int\":123,\"my_value_list\":[\"one\",\"two\",\"three\"],"
+      "\"my_value_list_of_lists\":[[1,2],[2,3],[],[4,5,6]],\"my_value_list_of_structs\":[{\"my_"
+      "value_bool\":false,\"my_value_boollist\":[true,false,true],\"my_value_empty_list\":[],\"my_"
+      "value_float\":1.234,\"my_value_int\":1234,\"my_value_list\":[\"one\",\"two\",\"three\"],"
+      "\"my_value_list_of_lists\":[[1,2],[2,3],[4,5,6]],\"my_value_string\":\"myvalue-override\","
+      "\"my_value_uintlist\":[0,1,3,5]},{\"var1\":0.15,\"var2\":-0.06,\"var3\":9}],\"my_value_"
+      "string\":\"myvalue\",\"my_value_uintlist\":[0,1,3,5]}",
       json);
 }
 
@@ -367,17 +377,91 @@ TEST(ConfigVisitor, PrettyJsonConfigVisitor) {
   },
   "my_proto_as_struct" : {
     "my_struct_in_proto" : {
+      "my_value_boollist" : [
+        true,
+        false,
+        true
+      ],
+      "my_value_empty_list" : [
+      ],
       "my_value_float" : 1.23,
       "my_value_int" : 123,
-      "my_value_string" : "myvalue"
+      "my_value_list" : [
+        "one",
+        "two",
+        "three"
+      ],
+      "my_value_list_of_lists" : [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          4,
+          5,
+          6
+        ]
+      ],
+      "my_value_string" : "myvalue",
+      "my_value_uintlist" : [
+        0,
+        1,
+        3,
+        5
+      ]
     }
   },
   "my_struct" : {
-    "my_value_float" : 1.23,
-    "my_value_int" : 123,
-    "my_value_string" : "myvalue"
+    "my_value_bool" : false,
+    "my_value_boollist" : [
+      true,
+      false,
+      true
+    ],
+    "my_value_empty_list" : [
+    ],
+    "my_value_float" : 1.234,
+    "my_value_int" : 1234,
+    "my_value_list" : [
+      "one",
+      "two",
+      "three"
+    ],
+    "my_value_list_of_lists" : [
+      [
+        1,
+        2
+      ],
+      [
+        2,
+        3
+      ],
+      [
+        4,
+        5,
+        6
+      ]
+    ],
+    "my_value_string" : "myvalue-override",
+    "my_value_uintlist" : [
+      0,
+      1,
+      3,
+      5
+    ]
   },
   "my_value_bool" : true,
+  "my_value_boollist" : [
+    true,
+    false,
+    true
+  ],
+  "my_value_empty_list" : [
+  ],
   "my_value_float" : 1.23,
   "my_value_int" : 123,
   "my_value_list" : [
@@ -395,10 +479,58 @@ TEST(ConfigVisitor, PrettyJsonConfigVisitor) {
       3
     ],
     [
+    ],
+    [
       4,
       5,
       6
     ]
+  ],
+  "my_value_list_of_structs" : [
+    {
+      "my_value_bool" : false,
+      "my_value_boollist" : [
+        true,
+        false,
+        true
+      ],
+      "my_value_empty_list" : [
+      ],
+      "my_value_float" : 1.234,
+      "my_value_int" : 1234,
+      "my_value_list" : [
+        "one",
+        "two",
+        "three"
+      ],
+      "my_value_list_of_lists" : [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          4,
+          5,
+          6
+        ]
+      ],
+      "my_value_string" : "myvalue-override",
+      "my_value_uintlist" : [
+        0,
+        1,
+        3,
+        5
+      ]
+    },
+    {
+      "var1" : 0.15,
+      "var2" : -0.06,
+      "var3" : 9
+    }
   ],
   "my_value_string" : "myvalue",
   "my_value_uintlist" : [

--- a/tests/config_parse_test.cpp
+++ b/tests/config_parse_test.cpp
@@ -231,7 +231,7 @@ auto baseDir() -> const std::filesystem::path& {
 
 auto filenameGenerator() -> std::vector<std::filesystem::path> {
   // don't try to parse files meant to be included
-  std::regex re_config(R"(config_example_\d+\.cfg)");
+  std::regex re_config(R"(config_example\d+\.cfg)");
   std::vector<std::filesystem::path> files;
   for (const auto& entry : std::filesystem::directory_iterator(baseDir())) {
     if (entry.is_regular_file()) {


### PR DESCRIPTION
Frequently requested feature is a JSON representation of a materialized FlexiConfig, this PR adds:
- a `<concepts>` based `Reader::visit(..)` API to walk the materialized config tree
- enable a `dump(..)` to a custom `ostream`
- a basic and pretty printing JSON visitor
- `python` bindings for `Reader::dump()` and `Reader::json(pretty=true)`
- tests C++ JSON visitor
- JSON is validated by the python JSON parser through the python bindings
- updated readme
- enable `python` testing from `Docker`
- fixed CMake Python integration, python test was not included in `ctest` and possibly not running in CI