### PR TITLE
[fix] Support expression types in lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,7 +356,7 @@ json = cfg.json()
 
 ### Introspection with Visitor API
 
-The C++ API provides a [visitor pattern](https://en.wikipedia.org/wiki/Visitor_pattern) through `flexi_cfg::Reader.visit(visitor)` to traverse the fully materialized FlexiConfig tree. This API offers a way to examine the configuration structure and data without requiring prior knowledge of specific `keys` or `types` in your code. One example of its utility is the [JSON Output](#JSON Output) functionality; additional formats can be similarly supported with ease.
+The C++ API provides a [visitor pattern](https://en.wikipedia.org/wiki/Visitor_pattern) through `flexi_cfg::Reader.visit(visitor)` to traverse the fully materialized FlexiConfig tree. This API offers a way to examine the configuration structure and data without requiring prior knowledge of specific `keys` or `types` in your code. One example of its utility is the [JSON Output](#json-output) functionality; additional formats can be similarly supported with ease.
 
 Implement a visitor `class` that matches one or more of the following [&lt;concepts&gt;](https://en.cppreference.com/w/cpp/language/constraints) and pass it to the `flexi_cfg::Reader` which will then invoke the respective callback functions as it encounters the various FlexiConfig elements the visitor is interested in:
 

--- a/examples/config_example17.cfg
+++ b/examples/config_example17.cfg
@@ -1,0 +1,8 @@
+# This example was added to verify that issue 149 is resolved.
+# Ensures that expressions in lists are evaluated correctly.
+
+pi = {{ pi }}
+
+struct foo {
+    bar = [$(pi), 1, {{ 2^12 }}, 3]
+}

--- a/examples/config_example5.cfg
+++ b/examples/config_example5.cfg
@@ -41,6 +41,8 @@ struct outer   {
         # Multi-line lists are handled
         key = [-0.123, 1.23e2
             , 1.023] # -5
+
+        with_expression = [$(outer.inner.val), 1, {{ 2^12 }}, 3]
       }
 
       key_after = 3

--- a/include/flexi_cfg/config/grammar.h
+++ b/include/flexi_cfg/config/grammar.h
@@ -98,6 +98,8 @@ struct BOOLEAN : peg::sor<TRUE, FALSE> {};
 
 struct STRING : peg::seq<peg::one<'"'>, peg::plus<peg::not_one<'"'>>, peg::one<'"'>> {};
 
+struct EXPRESSION : peg::seq<Eo, math::expression, Ec> {};
+
 template <typename Element>
 struct LIST_CONTENT_ : peg::list<Element, peg::seq<COMMA, TAIL>, peg::space> { using element = Element; };
 
@@ -112,13 +114,11 @@ struct LIST_ : peg::seq<SBo, TAIL, peg::opt<Content>, TAIL, SBc> {
 
 struct LIST;
 struct VALUE_LOOKUP;
-struct VALUE : peg::sor<HEX, NUMBER, STRING, BOOLEAN, VALUE_LOOKUP, LIST> {};
+struct VALUE : peg::sor<HEX, NUMBER, STRING, BOOLEAN, VALUE_LOOKUP, EXPRESSION, LIST> {};
 // 'seq' is used here so that the 'VALUE' action will collect the location information.
 struct LIST_ELEMENT : peg::seq<VALUE> {};
 struct LIST_CONTENT : LIST_CONTENT_<LIST_ELEMENT> {};
 struct LIST : LIST_<LIST_CONTENT> {};
-
-struct EXPRESSION : peg::seq<Eo, math::expression, Ec> {};
 
 // Account for all reserved keywords when looking for keys
 struct KEY : peg::seq<peg::not_at<RESERVED>, peg::lower, peg::star<peg::identifier_other>> {};

--- a/src/config_helpers.cpp
+++ b/src/config_helpers.cpp
@@ -601,10 +601,17 @@ void cleanupConfig(types::CfgMap& cfg, std::size_t depth) {
 
 auto listElementValid(const std::shared_ptr<types::ConfigList>& list, types::Type type) -> bool {
   bool valid = true;
-  if (type == types::Type::kVar || type == types::Type::kValueLookup ||
-      type == types::Type::kExpression) {
+  if (type == types::Type::kVar || type == types::Type::kValueLookup) {
     // This is a VAR or VALUE_LOOKUP, so we'll just continue. It's okay to mix these. We'll resolve
     // them later.
+  } else if (type == types::Type::kExpression) {
+    // An EXPRESSION is only valid if the type is kUnknown or a number (because an expression
+    // ultimately evaluates to a kNumber type)
+    if (list->list_element_type == types::Type::kUnknown) {
+      list->list_element_type = types::Type::kNumber;
+    } else if (list->list_element_type != types::Type::kNumber) {
+      valid = false;
+    }
   } else if (list->list_element_type == types::Type::kUnknown) {
     list->list_element_type = type;
   } else if (list->list_element_type != type) {

--- a/src/config_reader_example.cpp
+++ b/src/config_reader_example.cpp
@@ -167,6 +167,12 @@ auto main(int argc, char* argv[]) -> int {  // NOLINT(bugprone-exception-escape)
         flexi_cfg::logger::warn("Key '{}' does not exist", test_key);
       }
     }
+    {
+      // Ensure that expressions in lists are evaluated correctly
+      const auto* const my_nested_list_key = "outer.inner.test1.with_expression";
+      const auto out = cfg.getValue<std::vector<float>>(my_nested_list_key);
+      fmt::print("Value of '{}' is: {}\n", my_nested_list_key, fmt::join(out, ", "));
+    }
   } catch (const std::exception& e) {
     fmt::print(fmt::fg(fmt::color::red), "{}\n", e.what());
     return EXIT_FAILURE;

--- a/tests/config_parse_test.cpp
+++ b/tests/config_parse_test.cpp
@@ -75,11 +75,21 @@ TEST_P(InputString, Reader) {
   EXPECT_TRUE(cfg.exists("test2.inner.listWithComment"));
   EXPECT_EQ(cfg.getType("test2.inner.listWithComment"), flexi_cfg::config::types::Type::kList);
   EXPECT_EQ(cfg.getValue<std::vector<int>>("test2.inner.listWithComment"), std::vector({0, 2}));
+
   EXPECT_TRUE(cfg.exists("test2.inner.listWithTrailingComment"));
   EXPECT_EQ(cfg.getType("test2.inner.listWithTrailingComment"),
             flexi_cfg::config::types::Type::kList);
   EXPECT_EQ(cfg.getValue<std::vector<int>>("test2.inner.listWithTrailingComment"),
             std::vector({0, 2}));
+
+  EXPECT_TRUE(cfg.exists("test2.inner.listWithVarRef"));
+  EXPECT_EQ(cfg.getType("test2.inner.listWithVarRef"), flexi_cfg::config::types::Type::kList);
+  EXPECT_EQ(cfg.getValue<std::vector<int>>("test2.inner.listWithVarRef"), std::vector({1, 2, 4}));
+
+  EXPECT_TRUE(cfg.exists("test2.inner.listWithExpression"));
+  EXPECT_EQ(cfg.getType("test2.inner.listWithExpression"), flexi_cfg::config::types::Type::kList);
+  EXPECT_EQ(cfg.getValue<std::vector<float>>("test2.inner.listWithExpression"), std::vector<float>({1, 4096, 1.342}));
+
   EXPECT_TRUE(cfg.exists("test2"));
   EXPECT_EQ(cfg.getType("test2"), flexi_cfg::config::types::Type::kStruct);
   EXPECT_TRUE(cfg.exists("test1"));
@@ -203,6 +213,8 @@ struct test2 {
           0,
           2# I don't matter
         ]
+        listWithVarRef = [1, 2, $(b)]
+        listWithExpression = [1, {{ 2^12 }}, $(test1.key2)]
     }
 }
 


### PR DESCRIPTION
*  Modifies `LIST` grammer to support `EXPRESSION` types in lists.
*  Expressions are only supported if the other elements of the list resolve to a number type
*  Adds additional test coverage for expression in list support

Resolves #149 